### PR TITLE
Fix Build 99 compatibility and add cab display and wrist panel hosts (v3.3.0)

### DIFF
--- a/AutomatedMessages.cs
+++ b/AutomatedMessages.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Timers;
 
 namespace TwitchChat
@@ -17,7 +16,7 @@ namespace TwitchChat
         /// Collection of active message timers.
         /// </summary>
         private static readonly List<Timer> activeTimers = new();
-        
+
         /// <summary>
         /// Indicates whether any message timers are currently active and running.
         /// </summary>
@@ -29,61 +28,55 @@ namespace TwitchChat
         /// </summary>
         private static void TimedMessagesInit()
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "TimedMessagesInit";
             try
             {
                 StopAndClearTimers(); // Clear any existing timers before creating new ones
-                var messages = new Dictionary<string, (float timer, string color)>();
 
-                // Add messages if they are set and have a valid timer
-                if (!string.IsNullOrEmpty(TimedMessages.TimedMessage1) && TimedMessages.TimedMessage1Timer > 0)
-                    messages.Add(TimedMessages.TimedMessage1, (TimedMessages.TimedMessage1Timer, TimedMessages.TimedMessage1Color));
-                if (!string.IsNullOrEmpty(TimedMessages.TimedMessage2) && TimedMessages.TimedMessage2Timer > 0)
-                    messages.Add(TimedMessages.TimedMessage2, (TimedMessages.TimedMessage2Timer, TimedMessages.TimedMessage2Color));
-                if (!string.IsNullOrEmpty(TimedMessages.TimedMessage3) && TimedMessages.TimedMessage3Timer > 0)
-                    messages.Add(TimedMessages.TimedMessage3, (TimedMessages.TimedMessage3Timer, TimedMessages.TimedMessage3Color));
-                if (!string.IsNullOrEmpty(TimedMessages.TimedMessage4) && TimedMessages.TimedMessage4Timer > 0)
-                    messages.Add(TimedMessages.TimedMessage4, (TimedMessages.TimedMessage4Timer, TimedMessages.TimedMessage4Color));
-                if (!string.IsNullOrEmpty(TimedMessages.TimedMessage5) && TimedMessages.TimedMessage5Timer > 0)
-                    messages.Add(TimedMessages.TimedMessage5, (TimedMessages.TimedMessage5Timer, TimedMessages.TimedMessage5Color));
-
-                // Create and start timers for each message
-                foreach (var message in messages)
+                var messages = new List<(string text, float timer, string color)>
                 {
-                    if (message.Value.timer <= 0 || string.IsNullOrEmpty(message.Key) || message.Key == "MessageNotSet") 
+                    (TimedMessages.TimedMessage1, TimedMessages.TimedMessage1Timer, TimedMessages.TimedMessage1Color),
+                    (TimedMessages.TimedMessage2, TimedMessages.TimedMessage2Timer, TimedMessages.TimedMessage2Color),
+                    (TimedMessages.TimedMessage3, TimedMessages.TimedMessage3Timer, TimedMessages.TimedMessage3Color),
+                    (TimedMessages.TimedMessage4, TimedMessages.TimedMessage4Timer, TimedMessages.TimedMessage4Color),
+                    (TimedMessages.TimedMessage5, TimedMessages.TimedMessage5Timer, TimedMessages.TimedMessage5Color)
+                };
+
+                // Create and start timers for each configured message
+                foreach (var (text, timer, color) in messages)
+                {
+                    if (timer <= 0 || string.IsNullOrEmpty(text) || text == "MessageNotSet")
                         continue;
-                    
-                    Timer messageTimer = new(message.Value.timer * 1000); // Convert seconds to milliseconds
-                    string messageText = message.Key;
-                    string messageColor = message.Value.color;
-                    
-                    messageTimer.Elapsed += async (source, e) => 
+
+                    Timer messageTimer = new(timer * 1000); // Convert seconds to milliseconds
+                    string messageText = text;
+                    string messageColor = color;
+
+                    messageTimer.Elapsed += async (source, e) =>
                     {
                         if (messageColor.ToLower() == "normal")
                             await TwitchEventHandler.SendMessage(messageText);
                         else
                             await TwitchEventHandler.SendAnnouncement(messageText, messageColor);
-                        
-                        typeof(TimedMessages).GetProperty("lastTimedMessageSent", BindingFlags.NonPublic | BindingFlags.Static)
-                            ?.SetValue(null, $"{messageText} (Sent at {DateTime.Now:HH:mm:ss})");
+
+                        SetLastTimedMessageSent($"{messageText} (Sent at {DateTime.Now:HH:mm:ss})");
                     };
                     messageTimer.AutoReset = true;
                     messageTimer.Enabled = true;
                     activeTimers.Add(messageTimer);
-                    Main.LogEntry(methodName, $"Timer set for message: {messageText} with interval: {message.Value.timer} seconds");
+                    Main.LogEntry(methodName, $"Timer set for message: {messageText} with interval: {timer} seconds");
                 }
             }
             catch (Exception ex)
             {
                 Main.LogEntry(methodName, $"An error occurred: {ex.Message}");
-                typeof(TimedMessages).GetProperty("lastTimedMessageSent", BindingFlags.NonPublic | BindingFlags.Static)
-                    ?.SetValue(null, "Error initializing timed messages, see log for details");
+                SetLastTimedMessageSent("Error initializing timed messages, see log for details");
             }
         }
 
         public static void ToggleTimedMessages()
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "ToggleTimedMessages";
             try
             {
                 if (TimedMessages.TimedMessageSystemToggle)
@@ -124,27 +117,30 @@ namespace TwitchChat
                 Main.LogEntry(methodName, $"Error clearing timers: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// Records the most recent timed-message status so the settings UI can display it.
+        /// </summary>
         private static void SetLastTimedMessageSent(string message)
         {
-            typeof(TimedMessages).GetProperty("lastTimedMessageSent", BindingFlags.NonPublic | BindingFlags.Static)
-                ?.SetValue(null, message);
+            Settings.Instance.lastTimedMessageSent = message;
         }
 
         public static void CommandMessageProcessing(string message, string sender)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "CommandMessageProcessing";
             var settings = Settings.Instance;
 
             try
             {
                 string lowerMessage = message.ToLower();
-                
+
                 if (lowerMessage == "!commands" && settings.commandsMessageEnabled)
                 {
                     _ = TwitchEventHandler.SendWhisper(sender, settings.commandsMessage);
                     return;
                 }
-                
+
                 if (lowerMessage == "!info" && settings.infoMessageEnabled)
                 {
                     _ = TwitchEventHandler.SendWhisper(sender, settings.infoMessage);

--- a/Main.cs
+++ b/Main.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using UnityEngine;
 using UnityModManagerNet;
@@ -33,32 +32,24 @@ namespace TwitchChat
         {
             ModEntry = modEntry;
             ModEntry.Logger.Log("[Load] Load method started.");
+            string methodName = "Load";
 
             try
             {
-                // Initialize settings
-                Settings.Instance = UnityModManager.ModSettings.Load<Settings>(modEntry);
-                if (Settings.Instance == null)
-                {
-                    Settings.Instance = new Settings();
-                    Settings.Instance.debugLevel = DebugLevel.Minimal; // Set default debug level
-                }
+                // Settings first, so the logger knows the configured debug level
+                Settings.Instance = UnityModManager.ModSettings.Load<Settings>(modEntry) ?? new Settings();
                 Settings.Instance.authentication_status = "Unverified or not set";
 
-                // Begin using LogEntry
-                string methodName = MethodBase.GetCurrentMethod().Name;
-                LogEntry(methodName, "Load method started.");
+                // Log files next, so every LogEntry from here on has somewhere to go
+                InitializeLogFiles();
+                LogEntry(methodName, "Settings loaded and log files initialized.");
 
-                // Initialize UnityMainThreadDispatcher Object
+                // Initialize UnityMainThreadDispatcher Object (registers itself as the singleton in Awake)
                 GameObject dispatcherObject = new("UnityMainThreadDispatcher");
                 dispatcherObject.AddComponent<UnityMainThreadDispatcher>();
                 UnityEngine.Object.DontDestroyOnLoad(dispatcherObject);
                 ModEntry.Logger.Log("[Load] UnityMainThreadDispatcher initialized.");
                 LogEntry(methodName, "UnityMainThreadDispatcher initialized successfully.");
-
-                // Initialize TwitchChat Menu Object
-                GameObject menuObject = new("TwitchChatMenu");
-                LogEntry(methodName, "TwitchChatMenu object created.");
 
                 // Check for RemoteDispatch Mod
                 var remoteDispatchMod = UnityModManager.modEntries.FirstOrDefault(mod => mod.Info.Id == "RemoteDispatch");
@@ -78,20 +69,11 @@ namespace TwitchChat
                 ModEntry.OnToggle = OnToggle;
                 ModEntry.OnUpdate = OnUpdate;
                 LogEntry(methodName, "Registered mod toggle and update methods.");
-                
-                // Load the mod's settings
-                Settings.Instance = UnityModManager.ModSettings.Load<Settings>(modEntry);
-                Settings.Instance.authentication_status = "Unverified or not set";
-                LogEntry(methodName, "Settings loaded and initialized.");
-                
+
                 // Register the mod's GUI methods
                 modEntry.OnGUI = OnGUI;
                 modEntry.OnSaveGUI = OnSaveGUI;
                 LogEntry(methodName, "GUI methods registered.");
-
-                // Initialize the log files
-                InitializeLogFiles();
-                LogEntry(methodName, "Log files initialized successfully.");
 
                 // Activate Menu Managers
                 MenuManager.Instance.gameObject.SetActive(true);
@@ -114,9 +96,7 @@ namespace TwitchChat
         /// <param name="modEntry">The mod entry point provided by Unity Mod Manager.</param>
         private static void OnGUI(UnityModManager.ModEntry modEntry)
         {
-            _ = MethodBase.GetCurrentMethod().Name;
             Settings.Instance.DrawButtons();
-
         }
 
         /// <summary>
@@ -125,30 +105,30 @@ namespace TwitchChat
         /// <param name="modEntry">The mod entry point provided by Unity Mod Manager.</param>
         private static void OnSaveGUI(UnityModManager.ModEntry modEntry)
         {
-            _ = MethodBase.GetCurrentMethod().Name;
             Settings.Instance.Save(modEntry);
         }
 
         /// <summary>
         /// Handles the enabling and disabling of the mod.
+        /// A failure to show the in-game notification must never prevent the toggle itself.
         /// </summary>
-        /// <param name="_">Unused mod entry parameter.</param>
+        /// <param name="modEntry">The mod entry point provided by Unity Mod Manager.</param>
         /// <param name="isEnabled">Boolean indicating whether the mod should be enabled or disabled.</param>
         /// <returns>True if the toggle operation was successful, false otherwise.</returns>
-        private static bool OnToggle(UnityModManager.ModEntry _, bool isEnabled)
+        private static bool OnToggle(UnityModManager.ModEntry modEntry, bool isEnabled)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
-            if (ModEntry.Enabled)
+            string methodName = "OnToggle";
+            LogEntry(methodName, isEnabled ? "Mod Enabled!" : "Mod Disabled!");
+
+            try
             {
-                NotificationManager.AttachNotification("The TwitchChat mod is now receiving message notifications from your channel.", "null");
-                LogEntry(methodName, "Mod Enabled!");
-                ModEntry.Enabled = true;
+                NotificationManager.AttachNotification(isEnabled
+                    ? "The TwitchChat mod is now receiving message notifications from your channel."
+                    : "The TwitchChat mod is no longer receiving message notifications from your Channel.", "null");
             }
-            else
+            catch (Exception ex)
             {
-                NotificationManager.AttachNotification("The TwitchChat mod is no longer receiving message notifications from your Channel.", "null");
-                LogEntry(methodName, "Mod Disabled!");
-                ModEntry.Enabled = false;
+                LogEntry(methodName, $"Toggle notification failed: {ex.Message}");
             }
 
             return true;
@@ -161,7 +141,7 @@ namespace TwitchChat
         /// <param name="delta">Time in seconds since the last update.</param>
         private static void OnUpdate(UnityModManager.ModEntry modEntry, float delta)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "OnUpdate";
             try
             {
                 if (ModEntry.Enabled)
@@ -183,7 +163,7 @@ namespace TwitchChat
         {
             string logDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Mods", "TwitchChat", "Logs");
             string timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
-        
+
             // Create the directory if it does not exist
             if (!Directory.Exists(logDirectory))
             {
@@ -198,12 +178,12 @@ namespace TwitchChat
                     return;
                 }
             }
-        
+
             // Handle Debug Logs - Keep only last 3
             var debugLogFiles = Directory.GetFiles(logDirectory, "Debug_*.txt")
                                        .OrderByDescending(f => File.GetCreationTime(f))
                                        .ToList();
-        
+
             // Remove excess debug log files (keep only 3 most recent)
             for (int i = 2; i < debugLogFiles.Count; i++)
             {
@@ -216,17 +196,17 @@ namespace TwitchChat
                     ModEntry.Logger.Log($"Failed to delete old debug log: {debugLogFiles[i]}. Exception: {ex.Message}");
                 }
             }
-        
+
             // Create new log files with timestamp
             debugLog = Path.Combine(logDirectory, $"Debug_{timestamp}.txt");
             messageLog = Path.Combine(logDirectory, $"Messages_{timestamp}.txt");
-        
+
             // Create new files with headers
             try
             {
                 File.WriteAllText(debugLog, $"Debug log initialized on {DateTime.Now:yyyy-MM-dd HH:mm:ss}\n");
                 File.WriteAllText(messageLog, $"Message log initialized on {DateTime.Now:yyyy-MM-dd HH:mm:ss}\n");
-                
+
                 ModEntry.Logger.Log($"Initialized new debug log: {debugLog}");
                 ModEntry.Logger.Log($"Initialized new message log: {messageLog}");
             }
@@ -258,7 +238,7 @@ namespace TwitchChat
             {
                 if (Settings.Instance.debugLevel == DebugLevel.Off)
                     return;
-                if (Settings.Instance.debugLevel == DebugLevel.Minimal && 
+                if (Settings.Instance.debugLevel == DebugLevel.Minimal &&
                     !MinimalDebug.Contains(source))
                     return;
                 if (Settings.Instance.debugLevel == DebugLevel.Reduced &&
@@ -299,7 +279,8 @@ namespace TwitchChat
 
         /// <summary>
         /// Lists of debug sources used to control logging verbosity.
-        /// MinimalDebug contains sources that should be logged at Minimal level.
+        /// MinimalDebug contains sources that should be logged at Minimal level
+        /// (errors plus connection and authentication status).
         /// ReducedDebug contains sources that should be excluded at Reduced level.
         /// These lists help optimize logging performance and output clarity.
         /// </summary>
@@ -308,7 +289,20 @@ namespace TwitchChat
             "Load",
             "OnToggle",
             "OnUpdate",
-            "RegisterWebbSocketChatEvent"
+            "RegisterWebbSocketChatEvent",
+            "ConnectToWebSocket",
+            "OpenSocketAsync",
+            "ReconnectAsync",
+            "DisconnectFromWebSocket",
+            "CheckConnectionHealth",
+            "CloseSocketQuietly",
+            "GetOathToken",
+            "ValidateAuthToken",
+            "UnityMainThreadDispatcher",
+            "LicenseScan",
+            "HandleLicenseAttachment",
+            "CabDisplay",
+            "WristPanel"
         ];
 
         /// <summary>
@@ -317,6 +311,7 @@ namespace TwitchChat
         private static readonly HashSet<string> ReducedDebug =
         [
             "ReceiveMessages",
+            "HandleMessage",
             "AttachNotification"
         ];
     }

--- a/MenuManager.cs
+++ b/MenuManager.cs
@@ -1,70 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DV.CabControls;
+using DV.Items;
+using DV.Utils;
+using TwitchChat.PanelDisplays;
+using TwitchChat.PanelMenus;
 using UnityEngine;
 using UnityEngine.UI;
-using System.Reflection;
-using TwitchChat.PanelMenus;
-using TwitchChat.PanelDisplays;
-using System.Collections.Generic;
-using System;
-using DV.Booklets;
+using VRTK;
 
 namespace TwitchChat
 {
     /// <summary>
-    /// Represents a license instance with associated UI panels and game objects.
-    /// </summary>
-    /// <remarks>
-    /// Manages the relationship between in-game license objects and their corresponding UI elements,
-    /// including menu canvases, panel displays, and sticky tape attachments.
-    /// </remarks>
-    public class License
-    {
-        public string Name { get; private set; }
-        public int LicenseIndex { get; private set; }  // Add this property
-        public GameObject? LicenseObject { get; set; }
-        public GameObject? MenuCanvas { get; set; }
-        public bool AttachedToStickyTape { get; set; }
-        public GameObject? StickyTapeBase { get; set; }
-
-        // Panel Menus
-        public MainPanel? MainPanel { get; set; }
-        public StatusPanel? StatusPanel { get; set; }
-        public NotificationsPanel? NotificationsPanel { get; set; }
-        public StandardMessagesPanel? StandardMessagesPanel { get; set; }
-        public CommandMessagesPanel? CommandMessagesPanel { get; set; }
-        public TimedMessagesPanel? TimedMessagesPanel { get; set; }
-        public Config1Panel? Config1Panel { get; set; }
-        public Config2Panel? Config2Panel { get; set; }
-        public DebugPanel? DebugPanel { get; set; }
-
-        // Panel Displays
-        public LargeDisplayPanel? LargeDisplayPanel { get; set; }
-        public MediumDisplayPanel? MediumDisplayPanel { get; set; }
-        public SmallDisplayPanel? SmallDisplayPanel { get; set; }
-        public WideDisplayPanel? WideDisplayPanel { get; set; }
-
-        public License(string name, int index)  // Update constructor
-        {
-            Name = name;
-            LicenseIndex = index;
-        }
-    }
-
-    /// <summary>
     /// Manages the creation, positioning, and interaction of UI menus and panels for the Twitch Chat mod.
     /// </summary>
     /// <remarks>
-    /// This class is responsible for:
-    /// - Creating and managing UI canvases for each license
-    /// - Handling panel visibility and transitions
-    /// - Positioning menus relative to license objects
-    /// - Managing sticky tape attachments and paper visibility
-    /// - Coordinating message displays across all active panels
+    /// Three kinds of host carry the panel stack:
+    /// - Cab display: one canvas parented to the current locomotive interior, placed where the player is looking.
+    ///   Its pose is remembered per locomotive type and restored when the player enters that type again.
+    /// - Wrist panel: one canvas parented to a VR controller so it can be glanced at like a watch.
+    /// - License papers (legacy, optional): canvases riding on the six license items. Items are found through the
+    ///   game's storage system by prefab name, so the object name and hierarchy no longer matter.
     /// </remarks>
     public class MenuManager : MonoBehaviour
     {
+        private const float LicenseScanInterval = 1f;
+        private const float WristSearchInterval = 2f;
+        private const float BaseCanvasScale = 0.001f;
+        private const string PaperFallbackPath = "Pivot/TempPaper(Clone)(Clone) 0/Paper";
+
         private static MenuManager? instance;
-        private readonly Dictionary<string, License> licenses = new();
+        private readonly Dictionary<string, LicenseHost> licenses = new();
+        private readonly CabDisplayHost cabDisplay = new();
+        private readonly WristPanelHost wristPanel = new();
+        private readonly HashSet<string> paperLookupFailed = new();
         private GameObject? templateCanvas;
+
+        private float nextLicenseScanTime;
+        private bool licenseInventoryLogged;
+        private TrainCar? cabDisplayCar;
+        private Transform? wristAnchor;
+        private float nextWristSearchTime;
+
+        private KeyCode placeKey = KeyCode.None;
+        private KeyCode toggleKey = KeyCode.None;
+        private string parsedPlaceKey = string.Empty;
+        private string parsedToggleKey = string.Empty;
+
+        /// <summary>Every host, whether or not its canvas currently exists.</summary>
+        private IEnumerable<PanelHost> AllHosts
+        {
+            get
+            {
+                foreach (LicenseHost license in licenses.Values)
+                {
+                    yield return license;
+                }
+                yield return cabDisplay;
+                yield return wristPanel;
+            }
+        }
 
         /// <summary>
         /// Defines the types of panels available in the mod interface.
@@ -107,7 +103,7 @@ namespace TwitchChat
 
         private readonly Dictionary<PanelType, PanelConfig> panelConfigs = new()
         {
-            { PanelType.Main, new(new Vector2(200, 300), new Vector2(200, 300), Vector2.zero, Vector3.zero) },
+            { PanelType.Main, new(new Vector2(200, 330), new Vector2(200, 330), Vector2.zero, Vector3.zero) },
             { PanelType.Status, new(new Vector2(200, 300), new Vector2(200, 300), Vector2.zero, Vector3.zero) },
             { PanelType.Notifications, new(new Vector2(200, 300), new Vector2(200, 300), Vector2.zero, Vector3.zero) },
             { PanelType.LargeDisplay, new(new Vector2(1200, 650), new Vector2(1200, 650), Vector2.zero, Vector3.zero) },
@@ -141,12 +137,12 @@ namespace TwitchChat
         }
 
         /// <summary>
-        /// Initializes a new instance of MenuManager with predefined license configurations.
+        /// Initializes a new instance of MenuManager with the legacy license hosts.
         /// </summary>
         public MenuManager()
         {
-            // Initialize licenses with their index
-            string[] licenseNames = [
+            string[] licenseNames =
+            [
                 "LicenseTrainDriver",
                 "LicenseShunting",
                 "LicenseLocomotiveDE2",
@@ -157,13 +153,24 @@ namespace TwitchChat
 
             for (int i = 0; i < licenseNames.Length; i++)
             {
-                licenses.Add(licenseNames[i], new License(licenseNames[i], i));
+                licenses.Add(licenseNames[i], new LicenseHost(licenseNames[i], i));
             }
         }
 
         private void Awake()
         {
             CreateTemplateCanvas();
+            PlayerManager.CarChanged += OnPlayerCarChanged;
+        }
+
+        private void OnDestroy()
+        {
+            PlayerManager.CarChanged -= OnPlayerCarChanged;
+        }
+
+        private void OnApplicationQuit()
+        {
+            Settings.Instance.FlushPendingSave(force: true);
         }
 
         /// <summary>
@@ -171,10 +178,10 @@ namespace TwitchChat
         /// </summary>
         private void CreateTemplateCanvas()
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "CreateTemplateCanvas";
 
             Main.LogEntry(methodName, "Creating template canvas - VR Mode: " + VRManager.IsVREnabled());
-            
+
             templateCanvas = new GameObject("TemplateCanvas");
             templateCanvas.SetActive(false);
             DontDestroyOnLoad(templateCanvas);
@@ -183,13 +190,13 @@ namespace TwitchChat
             Canvas canvas = templateCanvas.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.WorldSpace;
             canvas.sortingOrder = 1000;
-            
+
             RectTransform canvasRect = templateCanvas.GetComponent<RectTransform>();
             canvasRect.sizeDelta = panelConfigs[PanelType.Main].CanvasSize;
-            canvasRect.localScale = Vector3.one * 0.001f;
+            canvasRect.localScale = Vector3.one * BaseCanvasScale;
 
-            // Add GraphicRaycaster with proper VR settings
-            var raycaster = templateCanvas.AddComponent<GraphicRaycaster>();
+            // Add GraphicRaycaster for non-VR clicks
+            templateCanvas.AddComponent<GraphicRaycaster>();
 
             // Create template panel
             GameObject menuPanel = new("MenuPanel");
@@ -212,20 +219,19 @@ namespace TwitchChat
         /// <param name="parent">Parent transform to attach panel templates to.</param>
         private void CreatePanelTemplates(Transform parent)
         {
-            // Create one of each panel type as templates
-            var mainPanel = new MainPanel(parent, null);
-            var statusPanel = new StatusPanel(parent);
-            var notificationsPanel = new NotificationsPanel(parent);
-            var largeDisplayPanel = new LargeDisplayPanel(parent);
-            var mediumDisplayPanel = new MediumDisplayPanel(parent);
-            var wideDisplayPanel = new WideDisplayPanel(parent);
-            var smallDisplayPanel = new SmallDisplayPanel(parent);
-            var standardMessagesPanel = new StandardMessagesPanel(parent);
-            var commandMessagesPanel = new CommandMessagesPanel(parent);
-            var timedMessagesPanel = new TimedMessagesPanel(parent);
-            var config1Panel = new Config1Panel(parent);
-            var config2Panel = new Config2Panel(parent);
-            var debugPanel = new DebugPanel(parent);
+            _ = new MainPanel(parent, null);
+            _ = new StatusPanel(parent);
+            _ = new NotificationsPanel(parent);
+            _ = new LargeDisplayPanel(parent);
+            _ = new MediumDisplayPanel(parent);
+            _ = new WideDisplayPanel(parent);
+            _ = new SmallDisplayPanel(parent);
+            _ = new StandardMessagesPanel(parent);
+            _ = new CommandMessagesPanel(parent);
+            _ = new TimedMessagesPanel(parent);
+            _ = new Config1Panel(parent);
+            _ = new Config2Panel(parent);
+            _ = new DebugPanel(parent);
 
             // Hide all template panels
             foreach (Transform child in parent)
@@ -235,178 +241,601 @@ namespace TwitchChat
         }
 
         /// <summary>
-        /// Updates the state and visibility of all license objects and their associated UI elements.
+        /// Drives all hosts once per frame.
         /// </summary>
         private void Update()
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            // Write any coalesced settings changes from the panels once they have settled
+            Settings.Instance.FlushPendingSave();
+            HandleHotkeys();
 
-            foreach (var license in licenses.Values)
+            bool inSession = PlayerManager.PlayerTransform != null;
+
+            if (inSession && Settings.Instance.licensePanelsEnabled)
             {
-                if (license.LicenseObject == null)
-                {
-                    license.LicenseObject = GameObject.Find(license.Name);
-                    if (license.LicenseObject != null)
-                    {
-                        Main.LogEntry(methodName, $"Attaching menu canvas to {license.Name}");
-                        
-                        if (license.MenuCanvas == null)
-                        {
-                            Main.LogEntry(methodName, $"Menu canvas for {license.Name} was null, creating...");
-                            CreateMenuCanvas(license);
-                        }
-                    }
-                }
-
-                if (license.LicenseObject != null)
-                {
-                    bool isLicenseActive = IsLicenseActive(license.LicenseObject);
-                    if (license.MenuCanvas != null)
-                    {
-                        // Only update canvas visibility if it's changed
-                        if (license.MenuCanvas.activeSelf != isLicenseActive)
-                        {
-                            license.MenuCanvas.SetActive(isLicenseActive);
-                            if (isLicenseActive)
-                            {
-                                // Re-show the active panel when canvas becomes visible
-                                string panelToShow = !string.IsNullOrEmpty(Settings.Instance.activePanels[license.LicenseIndex]) 
-                                    ? Settings.Instance.activePanels[license.LicenseIndex] 
-                                    : "Main";
-                                ShowPanel(panelToShow, license);
-                            }
-                        }
-                    }
-
-                    if (isLicenseActive)
-                    {
-                        UpdatePanelValues(license);
-                        HandleLicenseAttachment(license);
-                        HandlePaperVisibility(license);
-                    }
-                }
+                UpdateLicenseHosts();
             }
-        }
-
-        /// <summary>
-        /// Updates values displayed on active panels.
-        /// </summary>
-        /// <param name="license">The license containing panels to update.</param>
-        private void UpdatePanelValues(License license)
-        {
-            license.StatusPanel?.UpdateStatusPanelValues();
-            license.StandardMessagesPanel?.UpdateStandardMessagesPanelValues();
-            license.CommandMessagesPanel?.UpdateCommandMessagesPanelValues();
-        }
-
-        /// <summary>
-        /// Determines if a license object is currently active in the game world.
-        /// </summary>
-        /// <param name="license">The license GameObject to check.</param>
-        /// <returns>True if the license is active and not in inventory.</returns>
-        private bool IsLicenseActive(GameObject license)
-        {
-            if (!license.activeInHierarchy)
-                return false;
-
-            // Check if the license is in inventory by looking at its parent hierarchy
-            Transform current = license.transform;
-            while (current.parent != null)
+            else
             {
-                // Check for common inventory container names
-                if (current.parent.name.Contains("Inventory") || 
-                    current.parent.name.Contains("Storage") ||
-                    current.parent.name.Contains("Container"))
-                {
-                    return false;
-                }
-                current = current.parent;
+                ReleaseLicenseHosts();
             }
 
-            return true;
-        }
-
-        // BUG: Sticky tape returns after away from loco, detact/reattach fixes it
-        private void HandleLicenseAttachment(License license)
-        {
-            // Bounds checking for all arrays
-            if (license.LicenseObject == null)
-            {
-                Main.LogEntry("MenuManager.HandleLicenseAttachment", $"Invalid index or null object: {license.Name}");
-                return;
-            }
-
-            try
-            {
-                Transform current = license.LicenseObject!.transform;
-                bool currentlyAttached = false;
-                GameObject? newStickyTapeBase = null;
-                
-                while (current.parent != null)
-                {
-                    if (current.parent.name.Contains("StickyTape_Gadget"))
-                    {
-                        currentlyAttached = true;
-                        Transform baseTransform = current.parent.Find("LOD gadget_sticker_base");
-                        if (baseTransform != null)
-                        {
-                            newStickyTapeBase = baseTransform.gameObject;
-                        }
-                        break;
-                    }
-                    current = current.parent;
-                }
-
-                if (currentlyAttached != license.AttachedToStickyTape)
-                {
-                    license.AttachedToStickyTape = currentlyAttached;
-                    Main.LogEntry("HandleLicenseAttachment", $"License {license.Name} attachment to sticky tape changed: {license.AttachedToStickyTape}");
-                    
-                    if (license.AttachedToStickyTape && newStickyTapeBase != null)
-                    {
-                        license.StickyTapeBase = newStickyTapeBase;
-                        license.StickyTapeBase!.SetActive(false);
-                    }
-                    else if (!license.AttachedToStickyTape && license.StickyTapeBase != null)
-                    {
-                        license.StickyTapeBase!.SetActive(true);
-                        license.StickyTapeBase = null;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Main.LogEntry("MenuManager.HandleLicenseAttachment", $"Error: {e.Message}");
-            }
-        }
-
-        private void HandlePaperVisibility(License license)
-        {
-            if (license.LicenseObject != null)
-            {
-                Transform paperTransform = license.LicenseObject!.transform.Find("Pivot/TempPaper(Clone)(Clone) 0/Paper");
-                paperTransform?.gameObject.SetActive(false);
-            }
+            UpdateCabDisplay(inSession);
+            UpdateWristPanel(inSession);
         }
 
         private void LateUpdate()
         {
-            foreach (var license in licenses.Values)
+            foreach (LicenseHost license in licenses.Values)
             {
-                if (license.LicenseObject != null && license.MenuCanvas != null)
+                if (license.LicenseObject != null && license.MenuCanvas != null && license.MenuCanvas.activeSelf)
                 {
                     PositionNearObject(license);
                 }
             }
+
+            if (wristAnchor != null && wristPanel.MenuCanvas != null && wristPanel.MenuCanvas.activeSelf)
+            {
+                ApplyWristPose();
+            }
         }
 
-        public void OnPanelButtonClicked(string panelName, License license)
+        // ------------------------------------------------------------------
+        // Hotkeys (flat mode, or VR with a keyboard in reach)
+        // ------------------------------------------------------------------
+
+        private void HandleHotkeys()
         {
-            Main.LogEntry("OnPanelButtonClicked", $"Panel button clicked: {panelName} for license: {license.Name}");
-            ShowPanel(panelName, license);
+            placeKey = ParseKey(Settings.Instance.placeDisplayKey, ref parsedPlaceKey, placeKey);
+            toggleKey = ParseKey(Settings.Instance.toggleDisplayKey, ref parsedToggleKey, toggleKey);
+
+            if (placeKey != KeyCode.None && Input.GetKeyDown(placeKey))
+            {
+                PlaceCabDisplay();
+            }
+            if (toggleKey != KeyCode.None && Input.GetKeyDown(toggleKey))
+            {
+                ToggleCabDisplay();
+            }
         }
 
-        private void CreateMenuCanvas(License license)
+        private static KeyCode ParseKey(string name, ref string cachedName, KeyCode cached)
+        {
+            if (name == cachedName)
+            {
+                return cached;
+            }
+            cachedName = name;
+            return Enum.TryParse(name, true, out KeyCode key) ? key : KeyCode.None;
+        }
+
+        // ------------------------------------------------------------------
+        // Legacy license hosts
+        // ------------------------------------------------------------------
+
+        private void UpdateLicenseHosts()
+        {
+            if (Time.unscaledTime >= nextLicenseScanTime)
+            {
+                nextLicenseScanTime = Time.unscaledTime + LicenseScanInterval;
+                ScanForLicenseItems();
+            }
+
+            foreach (LicenseHost license in licenses.Values)
+            {
+                bool visible = license.LicenseObject != null && license.LicenseObject.activeInHierarchy;
+
+                if (license.MenuCanvas != null && license.MenuCanvas.activeSelf != visible)
+                {
+                    license.MenuCanvas.SetActive(visible);
+                    if (visible)
+                    {
+                        ShowPanel(license.ActivePanel, license);
+                    }
+                }
+
+                if (visible)
+                {
+                    UpdatePanelValues(license);
+                    HandleLicenseAttachment(license);
+                    HandlePaperVisibility(license);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Looks the six license items up through the game's storage system, which tracks every item
+        /// regardless of its GameObject name or where it is parented.
+        /// </summary>
+        private void ScanForLicenseItems()
+        {
+            string methodName = "LicenseScan";
+
+            StorageController storage = SingletonBehaviour<StorageController>.Instance;
+            if (storage == null)
+            {
+                return;
+            }
+
+            List<ItemBase> items;
+            try
+            {
+                items = storage.GetAllStorageItems();
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry(methodName, $"Could not list storage items: {ex.Message}");
+                return;
+            }
+
+            if (!licenseInventoryLogged)
+            {
+                licenseInventoryLogged = true;
+                List<string> licenseNames = items
+                    .Where(i => i != null && i.InventorySpecs != null)
+                    .Select(i => i.InventorySpecs.ItemPrefabName)
+                    .Where(n => !string.IsNullOrEmpty(n) && n.IndexOf("License", StringComparison.OrdinalIgnoreCase) >= 0)
+                    .Distinct()
+                    .ToList();
+                Main.LogEntry(methodName, $"Storage reports {items.Count} items. License items present: {(licenseNames.Count > 0 ? string.Join(", ", licenseNames) : "none")}");
+            }
+
+            foreach (LicenseHost license in licenses.Values)
+            {
+                if (license.Item != null && license.LicenseObject != null)
+                {
+                    continue; // still bound to a live item
+                }
+
+                ItemBase? match = items.FirstOrDefault(i => i != null && i.InventorySpecs != null && i.InventorySpecs.ItemPrefabName == license.PrefabName);
+                if (match == null)
+                {
+                    if (license.Item != null || license.LicenseObject != null)
+                    {
+                        Main.LogEntry(methodName, $"License item {license.PrefabName} is gone; releasing its menu.");
+                        UnbindLicense(license);
+                    }
+                    continue;
+                }
+
+                BindLicense(license, match);
+            }
+        }
+
+        private void BindLicense(LicenseHost license, ItemBase item)
+        {
+            UnbindLicense(license);
+            license.Item = item;
+            license.LicenseObject = item.gameObject;
+            paperLookupFailed.Remove(license.PrefabName);
+
+            Main.LogEntry("LicenseScan", $"Found license item {license.PrefabName} (object '{item.gameObject.name}', active: {item.gameObject.activeInHierarchy}, parent: '{(item.transform.parent != null ? item.transform.parent.name : "none")}')");
+
+            if (license.MenuCanvas == null)
+            {
+                CreateMenuCanvas(license);
+            }
+        }
+
+        private static void UnbindLicense(LicenseHost license)
+        {
+            license.Item = null;
+            license.LicenseObject = null;
+            license.PaperRenderer = null;
+            license.PaperObject = null;
+            license.AttachedToStickyTape = false;
+            license.StickyTapeBase = null;
+        }
+
+        /// <summary>
+        /// Hides license canvases and restores anything the mod hid, used when the legacy mode is off or no session is running.
+        /// </summary>
+        private void ReleaseLicenseHosts()
+        {
+            foreach (LicenseHost license in licenses.Values)
+            {
+                if (license.MenuCanvas != null && license.MenuCanvas.activeSelf)
+                {
+                    license.MenuCanvas.SetActive(false);
+                }
+                if (license.PaperRenderer != null && !license.PaperRenderer.enabled)
+                {
+                    license.PaperRenderer.enabled = true;
+                }
+                if (license.PaperObject != null && !license.PaperObject.activeSelf)
+                {
+                    license.PaperObject.SetActive(true);
+                }
+                if (license.StickyTapeBase != null && !license.StickyTapeBase.activeSelf)
+                {
+                    license.StickyTapeBase.SetActive(true);
+                }
+                license.StickyTapeBase = null;
+                license.AttachedToStickyTape = false;
+            }
+        }
+
+        /// <summary>
+        /// Tracks whether the license is snapped to a sticky tape gadget and hides the tape's backing while it is.
+        /// </summary>
+        private void HandleLicenseAttachment(LicenseHost license)
+        {
+            try
+            {
+                SnappableItem? snappable = license.Item != null ? license.Item.SnappableItem : null;
+                bool snapped = snappable != null && snappable.IsSnapped && snappable.SnappedTo != null;
+                if (snapped == license.AttachedToStickyTape)
+                {
+                    return;
+                }
+
+                license.AttachedToStickyTape = snapped;
+                Main.LogEntry("HandleLicenseAttachment", $"License {license.PrefabName} snapped to a mount: {snapped}");
+
+                if (snapped)
+                {
+                    GameObject? stickerBase = FindStickerBase(snappable!.SnappedTo!.transform);
+                    if (stickerBase != null)
+                    {
+                        license.StickyTapeBase = stickerBase;
+                        stickerBase.SetActive(false);
+                    }
+                }
+                else if (license.StickyTapeBase != null)
+                {
+                    license.StickyTapeBase.SetActive(true);
+                    license.StickyTapeBase = null;
+                }
+            }
+            catch (Exception e)
+            {
+                Main.LogEntry("HandleLicenseAttachment", $"Error: {e.Message}");
+            }
+        }
+
+        private static GameObject? FindStickerBase(Transform snapPoint)
+        {
+            Transform root = snapPoint;
+            for (int i = 0; i < 4 && root.parent != null && root.name.IndexOf("StickyTape", StringComparison.OrdinalIgnoreCase) < 0; i++)
+            {
+                root = root.parent;
+            }
+
+            foreach (Transform child in root.GetComponentsInChildren<Transform>(true))
+            {
+                if (child.name.IndexOf("gadget_sticker_base", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return child.gameObject;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Keeps the printed license page hidden while the canvas covers it. Prefers the game's Page component
+        /// and falls back to the fixed child path used by older builds.
+        /// </summary>
+        private void HandlePaperVisibility(LicenseHost license)
+        {
+            if (license.LicenseObject == null)
+            {
+                return;
+            }
+
+            if (license.PaperRenderer == null && license.PaperObject == null && !paperLookupFailed.Contains(license.PrefabName))
+            {
+                Page page = license.LicenseObject.GetComponentInChildren<Page>(true);
+                if (page != null && page.renderer != null)
+                {
+                    license.PaperRenderer = page.renderer;
+                }
+                else
+                {
+                    Transform fallback = license.LicenseObject.transform.Find(PaperFallbackPath);
+                    if (fallback != null)
+                    {
+                        license.PaperObject = fallback.gameObject;
+                    }
+                    else
+                    {
+                        paperLookupFailed.Add(license.PrefabName);
+                        Main.LogEntry("LicenseScan", $"Could not find the printed page of {license.PrefabName}; the canvas will overlay it instead.");
+                    }
+                }
+            }
+
+            if (license.PaperRenderer != null && license.PaperRenderer.enabled)
+            {
+                license.PaperRenderer.enabled = false;
+            }
+            if (license.PaperObject != null && license.PaperObject.activeSelf)
+            {
+                license.PaperObject.SetActive(false);
+            }
+        }
+
+        private void PositionNearObject(LicenseHost license)
+        {
+            if (license.MenuCanvas == null || license.LicenseObject == null)
+            {
+                return;
+            }
+
+            license.MenuCanvas.transform.position = license.LicenseObject.transform.position;
+            license.MenuCanvas.transform.rotation = license.LicenseObject.transform.rotation *
+                                                    Quaternion.Euler(90f, 180f, 0f) *
+                                                    Quaternion.Euler(panelConfigs[PanelType.Main].PanelRotationOffset);
+        }
+
+        // ------------------------------------------------------------------
+        // Cab display
+        // ------------------------------------------------------------------
+
+        private void UpdateCabDisplay(bool inSession)
+        {
+            if (!inSession)
+            {
+                cabDisplay.Placed = false;
+                cabDisplayCar = null;
+                return;
+            }
+
+            if (cabDisplay.MenuCanvas == null)
+            {
+                // First frame of a session, or the canvas was destroyed along with the car it was parented to
+                CreateMenuCanvas(cabDisplay);
+                cabDisplay.Placed = false;
+                cabDisplayCar = null;
+                TryRestoreCabDisplay(PlayerManager.Car);
+            }
+
+            GameObject canvas = cabDisplay.MenuCanvas!;
+            bool shouldShow = cabDisplay.Placed && Settings.Instance.cabDisplayVisible;
+            if (canvas.activeSelf != shouldShow)
+            {
+                canvas.SetActive(shouldShow);
+                if (shouldShow)
+                {
+                    ShowPanel(cabDisplay.ActivePanel, cabDisplay);
+                }
+            }
+
+            if (shouldShow)
+            {
+                canvas.transform.localScale = Vector3.one * BaseCanvasScale * Settings.Instance.cabDisplayScale;
+                UpdatePanelValues(cabDisplay);
+            }
+        }
+
+        private void OnPlayerCarChanged(TrainCar car)
+        {
+            if (car == null || cabDisplay.MenuCanvas == null || cabDisplayCar == car)
+            {
+                return;
+            }
+            TryRestoreCabDisplay(car);
+        }
+
+        /// <summary>
+        /// Moves the cab display onto the given car if a pose was saved for that locomotive type.
+        /// </summary>
+        private void TryRestoreCabDisplay(TrainCar? car)
+        {
+            if (car == null || cabDisplay.MenuCanvas == null)
+            {
+                return;
+            }
+
+            string key = CarKey(car);
+            CabDisplayPose? pose = FindPose(key);
+            if (pose == null)
+            {
+                return;
+            }
+
+            AttachCabDisplay(car, pose.localPosition, Quaternion.Euler(pose.localEuler));
+            Main.LogEntry("CabDisplay", $"Restored cab display pose for {key}.");
+        }
+
+        private void AttachCabDisplay(TrainCar car, Vector3 localPosition, Quaternion localRotation)
+        {
+            Transform parent = car.interior != null ? car.interior : car.transform;
+            Transform canvas = cabDisplay.MenuCanvas!.transform;
+            canvas.SetParent(parent, false);
+            canvas.localPosition = localPosition;
+            canvas.localRotation = localRotation;
+            canvas.localScale = Vector3.one * BaseCanvasScale * Settings.Instance.cabDisplayScale;
+            cabDisplayCar = car;
+            cabDisplay.Placed = true;
+        }
+
+        /// <summary>
+        /// Places the cab display in front of the player's view, parents it to the current car, and remembers the pose for that locomotive type.
+        /// </summary>
+        public void PlaceCabDisplay()
+        {
+            string methodName = "CabDisplay";
+
+            Camera? camera = PlayerManager.PlayerCamera != null ? PlayerManager.PlayerCamera : Camera.main;
+            if (camera == null || PlayerManager.PlayerTransform == null)
+            {
+                Main.LogEntry(methodName, "Cannot place the cab display outside of a game session.");
+                NotificationManager.SetVariable("alertMessage", "The cab display can only be placed while in a game session.");
+                return;
+            }
+
+            if (cabDisplay.MenuCanvas == null)
+            {
+                CreateMenuCanvas(cabDisplay);
+            }
+
+            Transform canvas = cabDisplay.MenuCanvas!.transform;
+            Vector3 position = camera.transform.position + camera.transform.forward * Settings.Instance.cabDisplayDistance;
+            Quaternion rotation = Quaternion.LookRotation(position - camera.transform.position, Vector3.up);
+
+            TrainCar? car = PlayerManager.Car;
+            Transform? parent = car != null
+                ? (car.interior != null ? car.interior : car.transform)
+                : WorldMover.OriginShiftParent;
+
+            canvas.SetParent(parent, true);
+            canvas.SetPositionAndRotation(position, rotation);
+            canvas.localScale = Vector3.one * BaseCanvasScale * Settings.Instance.cabDisplayScale;
+
+            cabDisplayCar = car;
+            cabDisplay.Placed = true;
+            Settings.Instance.cabDisplayVisible = true;
+
+            string location = "the world";
+            if (car != null)
+            {
+                location = CarKey(car);
+                SavePose(location, canvas.localPosition, canvas.localRotation.eulerAngles);
+            }
+            Settings.Instance.RequestSave();
+
+            canvas.gameObject.SetActive(true);
+            ShowPanel(cabDisplay.ActivePanel, cabDisplay);
+
+            Main.LogEntry(methodName, $"Cab display placed on {location} at {position}.");
+            NotificationManager.SetVariable("alertMessage", car != null
+                ? $"Cab display placed. Position saved for {location}."
+                : "Cab display placed. Not in a car, so this position is not saved.");
+        }
+
+        /// <summary>
+        /// Shows or hides the cab display without moving it.
+        /// </summary>
+        public void ToggleCabDisplay()
+        {
+            Settings.Instance.cabDisplayVisible = !Settings.Instance.cabDisplayVisible;
+            Settings.Instance.RequestSave();
+            Main.LogEntry("CabDisplay", $"Cab display visible: {Settings.Instance.cabDisplayVisible}");
+
+            if (Settings.Instance.cabDisplayVisible && !cabDisplay.Placed)
+            {
+                NotificationManager.SetVariable("alertMessage", "The cab display has not been placed in this locomotive yet. Use Place Display first.");
+            }
+        }
+
+        private static string CarKey(TrainCar car)
+        {
+            return car.carLivery != null ? car.carLivery.id : car.carType.ToString();
+        }
+
+        private static CabDisplayPose? FindPose(string key)
+        {
+            return Settings.Instance.cabDisplayPoses.FirstOrDefault(p => p.carId == key);
+        }
+
+        private static void SavePose(string key, Vector3 localPosition, Vector3 localEuler)
+        {
+            CabDisplayPose? pose = FindPose(key);
+            if (pose == null)
+            {
+                pose = new CabDisplayPose { carId = key };
+                Settings.Instance.cabDisplayPoses.Add(pose);
+            }
+            pose.localPosition = localPosition;
+            pose.localEuler = localEuler;
+        }
+
+        // ------------------------------------------------------------------
+        // Wrist panel
+        // ------------------------------------------------------------------
+
+        private void UpdateWristPanel(bool inSession)
+        {
+            bool wanted = inSession && Settings.Instance.wristPanelEnabled && VRManager.IsVREnabled();
+            if (!wanted)
+            {
+                if (wristPanel.MenuCanvas != null && wristPanel.MenuCanvas.activeSelf)
+                {
+                    wristPanel.MenuCanvas.SetActive(false);
+                }
+                if (!inSession)
+                {
+                    wristAnchor = null;
+                }
+                return;
+            }
+
+            if (wristPanel.MenuCanvas == null)
+            {
+                CreateMenuCanvas(wristPanel);
+                wristAnchor = null;
+            }
+
+            bool wantLeft = Settings.Instance.wristPanelOnLeftHand;
+            if (wristAnchor != null && wristPanel.AttachedToLeftHand != wantLeft)
+            {
+                wristAnchor = null; // hand preference changed, re-attach
+            }
+
+            if (wristAnchor == null && Time.unscaledTime >= nextWristSearchTime)
+            {
+                nextWristSearchTime = Time.unscaledTime + WristSearchInterval;
+                GameObject? hand = wantLeft ? VRTK_DeviceFinder.GetControllerLeftHand(true) : VRTK_DeviceFinder.GetControllerRightHand(true);
+                if (hand != null)
+                {
+                    wristAnchor = hand.transform;
+                    wristPanel.AttachedToLeftHand = wantLeft;
+                    wristPanel.MenuCanvas!.transform.SetParent(wristAnchor, false);
+                    ApplyWristPose();
+                    Main.LogEntry("WristPanel", $"Wrist panel attached to the {(wantLeft ? "left" : "right")} controller ('{hand.name}').");
+                }
+            }
+
+            GameObject canvas = wristPanel.MenuCanvas!;
+            bool shouldShow = wristAnchor != null;
+            if (canvas.activeSelf != shouldShow)
+            {
+                canvas.SetActive(shouldShow);
+                if (shouldShow)
+                {
+                    ShowPanel(wristPanel.ActivePanel, wristPanel);
+                }
+            }
+
+            if (shouldShow)
+            {
+                UpdatePanelValues(wristPanel);
+            }
+        }
+
+        private void ApplyWristPose()
+        {
+            if (wristPanel.MenuCanvas == null)
+            {
+                return;
+            }
+            Transform canvas = wristPanel.MenuCanvas.transform;
+            canvas.localPosition = Settings.Instance.wristPanelOffset;
+            canvas.localRotation = Quaternion.Euler(Settings.Instance.wristPanelRotation);
+            canvas.localScale = Vector3.one * BaseCanvasScale * Settings.Instance.wristPanelScale;
+        }
+
+        // ------------------------------------------------------------------
+        // Shared host plumbing
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Updates values displayed on active panels.
+        /// </summary>
+        private void UpdatePanelValues(PanelHost host)
+        {
+            host.StatusPanel?.UpdateStatusPanelValues();
+            host.StandardMessagesPanel?.UpdateStandardMessagesPanelValues();
+            host.CommandMessagesPanel?.UpdateCommandMessagesPanelValues();
+        }
+
+        public void OnPanelButtonClicked(string panelName, PanelHost host)
+        {
+            Main.LogEntry("OnPanelButtonClicked", $"Panel button clicked: {panelName} for host: {host.Name}");
+            ShowPanel(panelName, host);
+        }
+
+        private void CreateMenuCanvas(PanelHost host)
         {
             if (templateCanvas == null)
             {
@@ -414,76 +843,74 @@ namespace TwitchChat
                 return;
             }
 
-            // Clone the template
-            license.MenuCanvas = Instantiate(templateCanvas);
-            license.MenuCanvas.name = $"MenuCanvas_{license.Name}";
-            
-            Transform menuPanel = license.MenuCanvas.transform.Find("MenuPanel");
-            
+            // Clone the (inactive) template
+            host.MenuCanvas = Instantiate(templateCanvas);
+            host.MenuCanvas.name = $"MenuCanvas_{host.Name}";
+
+            Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
+
             // Create and wire up all panels from the templates
-            license.MainPanel = new MainPanel(menuPanel, license);
-            license.StatusPanel = new StatusPanel(menuPanel);
-            license.NotificationsPanel = new NotificationsPanel(menuPanel);
-            license.LargeDisplayPanel = new LargeDisplayPanel(menuPanel);
-            license.MediumDisplayPanel = new MediumDisplayPanel(menuPanel);
-            license.WideDisplayPanel = new WideDisplayPanel(menuPanel);
-            license.SmallDisplayPanel = new SmallDisplayPanel(menuPanel);
-            license.StandardMessagesPanel = new StandardMessagesPanel(menuPanel);
-            license.CommandMessagesPanel = new CommandMessagesPanel(menuPanel);
-            license.TimedMessagesPanel = new TimedMessagesPanel(menuPanel);
-            license.Config1Panel = new Config1Panel(menuPanel);
-            license.Config2Panel = new Config2Panel(menuPanel);
-            license.DebugPanel = new DebugPanel(menuPanel);
+            host.MainPanel = new MainPanel(menuPanel, host);
+            host.StatusPanel = new StatusPanel(menuPanel);
+            host.NotificationsPanel = new NotificationsPanel(menuPanel);
+            host.LargeDisplayPanel = new LargeDisplayPanel(menuPanel);
+            host.MediumDisplayPanel = new MediumDisplayPanel(menuPanel);
+            host.WideDisplayPanel = new WideDisplayPanel(menuPanel);
+            host.SmallDisplayPanel = new SmallDisplayPanel(menuPanel);
+            host.StandardMessagesPanel = new StandardMessagesPanel(menuPanel);
+            host.CommandMessagesPanel = new CommandMessagesPanel(menuPanel);
+            host.TimedMessagesPanel = new TimedMessagesPanel(menuPanel);
+            host.Config1Panel = new Config1Panel(menuPanel);
+            host.Config2Panel = new Config2Panel(menuPanel);
+            host.DebugPanel = new DebugPanel(menuPanel);
 
             // Explicitly hide all panels immediately after creation
-            HideAllPanels(license);
+            HideAllPanels(host);
 
             // Wire up back button events
-            if (license.StatusPanel != null) license.StatusPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.NotificationsPanel != null) license.NotificationsPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.LargeDisplayPanel != null) license.LargeDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.MediumDisplayPanel != null) license.MediumDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.WideDisplayPanel != null) license.WideDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.SmallDisplayPanel != null) license.SmallDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.StandardMessagesPanel != null) license.StandardMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.CommandMessagesPanel != null) license.CommandMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.TimedMessagesPanel != null) license.TimedMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.Config1Panel != null) license.Config1Panel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.Config2Panel != null) license.Config2Panel.OnBackButtonClicked += () => ShowPanel("Main", license);
-            if (license.DebugPanel != null) license.DebugPanel.OnBackButtonClicked += () => ShowPanel("Main", license);
+            host.StatusPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.NotificationsPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.LargeDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.MediumDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.WideDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.SmallDisplayPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.StandardMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.CommandMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.TimedMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.Config1Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.Config2Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.DebugPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
 
-            // Show initial panel
-            string panelToShow = !string.IsNullOrEmpty(Settings.Instance.activePanels[license.LicenseIndex]) 
-                ? Settings.Instance.activePanels[license.LicenseIndex] 
-                : "Main";
-            ShowPanel(panelToShow, license);
+            Main.LogEntry("CreateMenuCanvas", $"Created panel stack for host {host.Name}.");
         }
 
-        private void HideAllPanels(License license)
+        private static void HideAllPanels(PanelHost host)
         {
-            license.MainPanel?.Hide();
-            license.StatusPanel?.Hide();
-            license.NotificationsPanel?.Hide();
-            license.LargeDisplayPanel?.Hide();
-            license.MediumDisplayPanel?.Hide();
-            license.WideDisplayPanel?.Hide();
-            license.SmallDisplayPanel?.Hide();
-            license.StandardMessagesPanel?.Hide();
-            license.CommandMessagesPanel?.Hide();
-            license.TimedMessagesPanel?.Hide();
-            license.Config1Panel?.Hide();
-            license.Config2Panel?.Hide();
-            license.DebugPanel?.Hide();
+            host.MainPanel?.Hide();
+            host.StatusPanel?.Hide();
+            host.NotificationsPanel?.Hide();
+            host.LargeDisplayPanel?.Hide();
+            host.MediumDisplayPanel?.Hide();
+            host.WideDisplayPanel?.Hide();
+            host.SmallDisplayPanel?.Hide();
+            host.StandardMessagesPanel?.Hide();
+            host.CommandMessagesPanel?.Hide();
+            host.TimedMessagesPanel?.Hide();
+            host.Config1Panel?.Hide();
+            host.Config2Panel?.Hide();
+            host.DebugPanel?.Hide();
         }
 
-        private void ShowPanel(string panelName, License license)
+        private void ShowPanel(string panelName, PanelHost host)
         {
-            if (license.MenuCanvas == null || !license.MenuCanvas!.activeSelf)
+            if (host.MenuCanvas == null || !host.MenuCanvas.activeSelf)
+            {
                 return;
-            
-            Main.LogEntry("ShowPanel", $"Showing panel {panelName} for license {license.Name} (index: {license.LicenseIndex})");
+            }
 
-            HideAllPanels(license);
+            Main.LogEntry("ShowPanel", $"Showing panel {panelName} on host {host.Name}");
+
+            HideAllPanels(host);
 
             PanelType panelType = panelName switch
             {
@@ -504,13 +931,13 @@ namespace TwitchChat
             };
 
             // Apply the configuration for this panel type
-            var config = panelConfigs[panelType];
-            var menuPanel = license.MenuCanvas!.transform.Find("MenuPanel");
+            PanelConfig config = panelConfigs[panelType];
+            Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
             if (menuPanel != null)
             {
-                RectTransform canvasRect = license.MenuCanvas!.GetComponent<RectTransform>();
+                RectTransform canvasRect = host.MenuCanvas.GetComponent<RectTransform>();
                 RectTransform panelRect = menuPanel.GetComponent<RectTransform>();
-                
+
                 canvasRect.sizeDelta = config.CanvasSize;
                 panelRect.sizeDelta = config.PanelSize;
                 panelRect.localPosition = config.PanelPosition;
@@ -521,302 +948,233 @@ namespace TwitchChat
             switch (panelType)
             {
                 case PanelType.Main:
-                    license.MainPanel?.Show();
+                    host.MainPanel?.Show();
                     break;
                 case PanelType.Status:
-                    license.StatusPanel?.Show();
+                    host.StatusPanel?.Show();
                     break;
                 case PanelType.Notifications:
-                    license.NotificationsPanel?.Show();
+                    host.NotificationsPanel?.Show();
                     break;
                 case PanelType.LargeDisplay:
-                    license.LargeDisplayPanel?.Show();
+                    host.LargeDisplayPanel?.Show();
                     break;
                 case PanelType.MediumDisplay:
-                    license.MediumDisplayPanel?.Show();
+                    host.MediumDisplayPanel?.Show();
                     break;
                 case PanelType.WideDisplay:
-                    license.WideDisplayPanel?.Show();
+                    host.WideDisplayPanel?.Show();
                     break;
                 case PanelType.SmallDisplay:
-                    license.SmallDisplayPanel?.Show();
+                    host.SmallDisplayPanel?.Show();
                     break;
                 case PanelType.StandardMessages:
-                    license.StandardMessagesPanel?.Show();
+                    host.StandardMessagesPanel?.Show();
                     break;
                 case PanelType.CommandMessages:
-                    license.CommandMessagesPanel?.Show();
+                    host.CommandMessagesPanel?.Show();
                     break;
                 case PanelType.TimedMessages:
-                    license.TimedMessagesPanel?.Show();
+                    host.TimedMessagesPanel?.Show();
                     break;
                 case PanelType.Config1:
-                    license.Config1Panel?.Show();
+                    host.Config1Panel?.Show();
                     break;
                 case PanelType.Config2:
-                    license.Config2Panel?.Show();
+                    host.Config2Panel?.Show();
                     break;
                 case PanelType.Debug:
-                    license.DebugPanel?.Show();
+                    host.DebugPanel?.Show();
                     break;
             }
 
-            // Save the active panel state to the correct index
-            Settings.Instance.activePanels[license.LicenseIndex] = panelName;
-            Settings.Instance.Save(Main.ModEntry);
-            Main.LogEntry("ShowPanel", $"Saving active panel state for license {license.Name} at index {license.LicenseIndex}: {panelName}");
-        }
-
-        private void PositionNearObject(License license)
-        {
-            if (license.MenuCanvas == null)
-            {
-                Main.LogEntry("MenuManager.PositionNearObject", "Menu Canvas is not initialized.");
-                return;
-            }
-
-            if (license.LicenseObject == null) return;
-
-            Vector3 targetPosition = license.LicenseObject.transform.position;
-            license.MenuCanvas.transform.position = targetPosition;
-
-            license.MenuCanvas.transform.rotation = license.LicenseObject.transform.rotation * 
-                                         Quaternion.Euler(90f, 180f, 0f) * 
-                                         Quaternion.Euler(panelConfigs[PanelType.Main].PanelRotationOffset);
+            // Remember the active panel for this host
+            host.ActivePanel = panelName;
+            Settings.Instance.RequestSave();
         }
 
         /// <summary>
-        /// Adds a chat message to all active display panels.
+        /// Adds a chat message to the display panels of every host that has been created.
         /// </summary>
         /// <param name="username">The username of the message sender.</param>
         /// <param name="message">The chat message content.</param>
         public void AddMessageToPanelDisplays(string username, string message)
         {
-            try
+            foreach (PanelHost host in AllHosts)
             {
-                foreach (var license in licenses.Values)
+                if (host.MenuCanvas == null)
                 {
-                    if (license.MenuCanvas != null && license.MenuCanvas.activeSelf)
-                    {
-                        try
-                        {
-                            // Add message to all display panels regardless of visibility
-                            license.LargeDisplayPanel?.AddChatMessage(username, message);
-                            license.MediumDisplayPanel?.AddChatMessage(username, message);
-                            license.WideDisplayPanel?.AddChatMessage(username, message);
-                            license.SmallDisplayPanel?.AddChatMessage(username, message);
-                        }
-                        catch (System.Exception ex)
-                        {
-                            Main.LogEntry("MenuManager.AddMessageToPanelDisplays", 
-                                $"Error adding message to license {license.Name}: {ex.Message}");
-                        }
-                    }
+                    continue;
                 }
-            }
-            catch (System.Exception ex)
-            {
-                Main.LogEntry("MenuManager.AddMessageToPanelDisplays", 
-                    $"Error in AddMessageToPanelDisplays: {ex.Message}");
+
+                try
+                {
+                    // Add message to all display panels regardless of which one is showing
+                    host.LargeDisplayPanel?.AddChatMessage(username, message);
+                    host.MediumDisplayPanel?.AddChatMessage(username, message);
+                    host.WideDisplayPanel?.AddChatMessage(username, message);
+                    host.SmallDisplayPanel?.AddChatMessage(username, message);
+                }
+                catch (Exception ex)
+                {
+                    Main.LogEntry("MenuManager.AddMessageToPanelDisplays", $"Error adding message to host {host.Name}: {ex.Message}");
+                }
             }
         }
 
-        /// <summary>
-        /// Updates the notification toggle state across all licenses.
-        /// </summary>
-        /// <param name="value">The new toggle state to apply.</param>
         public void UpdateAllNotificationToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.NotificationsPanel != null)
-                {
-                    license.NotificationsPanel.UpdateNotificationsEnabled(value);
-                }
+                host.NotificationsPanel?.UpdateNotificationsEnabled(value);
             }
         }
 
         public void UpdateAllNotificationDurations(float value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.NotificationsPanel != null)
-                {
-                    license.NotificationsPanel.UpdateNotificationDuration(value);
-                }
+                host.NotificationsPanel?.UpdateNotificationDuration(value);
             }
         }
+
         public void UpdateAllProcessOwnToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.DebugPanel != null)
-                {
-                    license.DebugPanel.UpdateProcessOwn(value);
-                }
+                host.DebugPanel?.UpdateProcessOwn(value);
             }
         }
+
         public void UpdateAllProcessDuplicatesToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.DebugPanel != null)
-                {
-                    license.DebugPanel.UpdateProcessDuplicates(value);
-                }
+                host.DebugPanel?.UpdateProcessDuplicates(value);
             }
         }
 
         public void UpdateAllConnectMessageEnabledToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.StandardMessagesPanel != null)
-                {
-                    license.StandardMessagesPanel.UpdateConnectMessageEnabled(value);
-                }
+                host.StandardMessagesPanel?.UpdateConnectMessageEnabled(value);
             }
         }
-
-        // public void UpdateAllNewFollowerMessageEnabledToggles(bool value)
-        // {
-        //     foreach (var license in licenses.Values)
-        //     {
-        //         if (license.StandardMessagesPanel != null)
-        //         {
-        //             license.StandardMessagesPanel.UpdateNewFollowerMessageEnabled(value);
-        //         }
-        //     }
-        // }
-
-        // public void UpdateAllNewSubscriberMessageEnabledToggles(bool value)
-        // {
-        //     foreach (var license in licenses.Values)
-        //     {
-        //         if (license.StandardMessagesPanel != null)
-        //         {
-        //             license.StandardMessagesPanel.UpdateNewSubscriberMessageEnabled(value);
-        //         }
-        //     }
-        // }
 
         public void UpdateAllDisconnectMessageEnabledToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.StandardMessagesPanel != null)
-                {
-                    license.StandardMessagesPanel.UpdateDisconnectMessageEnabled(value);
-                }
+                host.StandardMessagesPanel?.UpdateDisconnectMessageEnabled(value);
             }
         }
+
         public void UpdateCommandsMessageToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.CommandMessagesPanel != null)
-                {
-                    license.CommandMessagesPanel.UpdateCommandsMessageEnabled(value);
-                }
+                host.CommandMessagesPanel?.UpdateCommandsMessageEnabled(value);
             }
         }
+
         public void UpdateInfoMessageToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.CommandMessagesPanel != null)
-                {
-                    license.CommandMessagesPanel.UpdateInfoMessageEnabled(value);
-                }
+                host.CommandMessagesPanel?.UpdateInfoMessageEnabled(value);
             }
         }
+
         public void UpdateAllTimedMessageToggles(bool value)
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.TimedMessagesPanel != null)
-                {
-                    license.TimedMessagesPanel.UpdateTimedMessagesEnabled(value);
-                }
+                host.TimedMessagesPanel?.UpdateTimedMessagesEnabled(value);
             }
         }
+
         public void UpdateAllPanelBackgrounds()
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.MenuCanvas != null)
+                if (host.MenuCanvas == null)
                 {
-                    // Update menu panel background
-                    Transform menuPanel = license.MenuCanvas.transform.Find("MenuPanel");
-                    if (menuPanel != null)
-                    {
-                        // Update the main panel background
-                        Image panelImage = menuPanel.GetComponent<Image>();
-                        if (panelImage != null)
-                        {
-                            panelImage.color = Settings.Instance.panelColor;
-                        }
+                    continue;
+                }
 
-                        // Find all panel backgrounds (direct children of MenuPanel only)
-                        foreach (Transform child in menuPanel)
+                Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
+                if (menuPanel == null)
+                {
+                    continue;
+                }
+
+                Image panelImage = menuPanel.GetComponent<Image>();
+                if (panelImage != null)
+                {
+                    panelImage.color = Settings.Instance.panelColor;
+                }
+
+                // Direct children of MenuPanel whose name contains "Panel" are the panel backgrounds
+                foreach (Transform child in menuPanel)
+                {
+                    if (child.name.Contains("Panel"))
+                    {
+                        Image childImage = child.GetComponent<Image>();
+                        if (childImage != null)
                         {
-                            // Only update if it's a panel (contains "Panel" in name)
-                            if (child.name.Contains("Panel"))
-                            {
-                                Image childImage = child.GetComponent<Image>();
-                                if (childImage != null)
-                                {
-                                    childImage.color = Settings.Instance.panelColor;
-                                }
-                            }
+                            childImage.color = Settings.Instance.panelColor;
                         }
                     }
                 }
             }
         }
+
         public void UpdateAllSectionBackgrounds()
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.MenuCanvas != null)
+                if (host.MenuCanvas == null)
                 {
-                    // Update menu panel background
-                    Transform menuPanel = license.MenuCanvas.transform.Find("MenuPanel");
-                    if (menuPanel != null)
+                    continue;
+                }
+
+                Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
+                if (menuPanel == null)
+                {
+                    continue;
+                }
+
+                foreach (Image image in menuPanel.GetComponentsInChildren<Image>(true))
+                {
+                    if (image.gameObject.name.EndsWith("Section"))
                     {
-                        // Find all section backgrounds recursively
-                        Image[] sectionImages = menuPanel.GetComponentsInChildren<Image>(true);
-                        foreach (Image image in sectionImages)
-                        {
-                            // Check if this image belongs to a section (parent GameObject name ends with "Section")
-                            if (image.gameObject.name.EndsWith("Section"))
-                            {
-                                image.color = Settings.Instance.sectionColor;
-                            }
-                        }
+                        image.color = Settings.Instance.sectionColor;
                     }
                 }
             }
         }
+
         public void UpdateAllButtonColors()
         {
-            foreach (var license in licenses.Values)
+            foreach (PanelHost host in AllHosts)
             {
-                if (license.MenuCanvas != null)
+                if (host.MenuCanvas == null)
                 {
-                    Transform menuPanel = license.MenuCanvas.transform.Find("MenuPanel");
-                    if (menuPanel != null)
+                    continue;
+                }
+
+                Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
+                if (menuPanel == null)
+                {
+                    continue;
+                }
+
+                foreach (Image image in menuPanel.GetComponentsInChildren<Image>(true))
+                {
+                    if (image.GetComponent<Button>() != null)
                     {
-                        // Find all button images recursively
-                        Image[] buttonImages = menuPanel.GetComponentsInChildren<Image>(true);
-                        foreach (Image image in buttonImages)
-                        {
-                            // Only update images that are attached to buttons
-                            if (image.GetComponent<Button>() != null)
-                            {
-                                image.color = Settings.Instance.buttonColor;
-                            }
-                        }
+                        image.color = Settings.Instance.buttonColor;
                     }
                 }
             }

--- a/NotificationManager.cs
+++ b/NotificationManager.cs
@@ -2,14 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace TwitchChat
 {
     /// <summary>
     /// Manages in-game notifications and Twitch chat message display.
-    /// Handles message queuing, processing, and visual presentation of notifications.
-    /// Provides real-time chat integration and notification attachment to game objects.
+    /// Handles message routing, command dispatch, and visual presentation of notifications.
+    /// All Unity work is marshalled to the main thread, so callers may run on any thread.
     /// </summary>
     public class NotificationManager
     {
@@ -61,236 +63,127 @@ namespace TwitchChat
         {
             return NewNotificationQueue.ContainsKey(notification_type) ? NewNotificationQueue[notification_type] : null;
         }
+
         public static void WebSocketNotificationTest()
         {
             SetVariable("webSocketNotification", $"Message Queue Attachment Notification Test #{messageQueueTestCounter}");
-            messageQueueTestCounter++;            
-        }
-        private class TwitchMessage
-        {
-            public Metadata? metadata { get; set; }
-            public Payload? payload { get; set; }
-        }
-        private class Metadata
-        {
-            public string? subscription_type { get; set; }
-        }
-        private class Payload
-        {
-            public Event? @event { get; set; }
-        }
-        private class Event
-        {
-            public string? chatter_user_name { get; set; }
-            public string? chatter_user_id { get; set; }
-            public Message? message { get; set; }
-        }
-        private class Message
-        {
-            public string? text { get; set; }
+            messageQueueTestCounter++;
         }
 
         /// <summary>
-        /// Handles incoming Twitch chat notifications and processes commands.
+        /// Handles an incoming Twitch EventSub notification and processes commands.
+        /// Safe to call from the WebSocket receive thread.
         /// </summary>
-        /// <param name="jsonMessage">The raw JSON message received from Twitch.</param>
-        public static void HandleNotification(dynamic jsonMessage)
+        /// <param name="message">The parsed EventSub message envelope.</param>
+        public static void HandleNotification(JObject message)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = "HandleNotification";
 
-            Main.LogEntry(methodName, "Attempting to handle notification...");
-
-            // if (Settings.Instance.notificationsEnabled == false)
-            // {
-            //     Main.LogEntry(methodName, "Notification system disabled, skipping.");
-            //     return;
-            // }
-            // Main.LogEntry(methodName, "Notification system enabled, continuing...");
-        
             try
             {
-                string jsonString = jsonMessage.ToString();
-                Main.LogEntry($"{methodName}", $"Processing message: {jsonString}");
-                
-                if (!jsonString.Contains("\"subscription_type\":\"channel.chat.message\""))
+                string subscriptionType = (string?)message.SelectToken("metadata.subscription_type") ?? string.Empty;
+                if (subscriptionType != "channel.chat.message")
                 {
-                    Main.LogEntry($"{methodName}", "Not a chat message, skipping");
+                    Main.LogEntry(methodName, $"Ignoring non-chat notification: {subscriptionType}");
                     return;
                 }
-                
-                string chatter = ExtractValue(jsonString, "chatter_user_name");
-                string chatterId = ExtractValue(jsonString, "chatter_user_id");
-                string text = ExtractValue(jsonString, "text");
 
-                Main.LogEntry($"{methodName}", $"Extracted values - Chatter: {chatter}, ChatterId: {chatterId}, Text: {text}");
+                JToken? chatEvent = message.SelectToken("payload.event");
+                string chatter = (string?)chatEvent?["chatter_user_name"] ?? string.Empty;
+                string chatterId = (string?)chatEvent?["chatter_user_id"] ?? string.Empty;
+                string text = (string?)chatEvent?.SelectToken("message.text") ?? string.Empty;
+
+                Main.LogEntry(methodName, $"Extracted values - Chatter: {chatter}, ChatterId: {chatterId}, Text: {text}");
 
                 // Skip if any required values are missing
                 if (string.IsNullOrEmpty(chatter) || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(chatterId))
                 {
-                    Main.LogEntry($"{methodName}", "Skipping message due to missing required values");
+                    Main.LogEntry(methodName, "Skipping message due to missing required values");
                     return;
                 }
 
                 // Skip processing if message is from ourselves (unless debug setting is enabled)
                 if (chatterId == TwitchEventHandler.user_id && !Settings.Instance.processOwn)
                 {
-                    Main.LogEntry($"{methodName}", $"Skipping message from self (ID: {chatterId})");
+                    Main.LogEntry(methodName, $"Skipping message from self (ID: {chatterId})");
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(chatter) && !string.IsNullOrEmpty(text))
+                Main.LogEntry("ReceivedMessage", $"{chatter}: {text}");
+
+                // Redirect command messages
+                if (text.StartsWith("!"))
                 {
-                    Main.LogEntry($"{methodName}", $"Valid message received from {chatter}: {text}");
+                    AutomatedMessages.CommandMessageProcessing(text, chatterId);
+                    return;
+                }
 
-                    // Redirect command messages
-                    if (text.ToLower().StartsWith("!"))
-                    {
-                        AutomatedMessages.CommandMessageProcessing(text, chatterId);
-                        return;
-                    }
-
-                    // Add message to in-game display boards
+                // Everything that touches Unity objects runs on the main thread.
+                UnityMainThreadDispatcher.Instance().Enqueue(() =>
+                {
                     try
                     {
                         MenuManager.Instance.AddMessageToPanelDisplays(chatter, text);
                     }
                     catch (Exception ex)
                     {
-                        Main.LogEntry($"{methodName}", $"Failed to add message to display boards: {ex.Message}");
+                        Main.LogEntry(methodName, $"Failed to add message to display boards: {ex.Message}");
                     }
 
-                    // Check if notification system is enabled
-                    if (Settings.Instance.notificationsEnabled == false)
+                    if (!Settings.Instance.notificationsEnabled)
                     {
-                        Main.LogEntry(methodName, "Notification system disabled, skipping.");
+                        Main.LogEntry(methodName, "Notification system disabled, skipping popup.");
                         return;
                     }
-                    Main.LogEntry(methodName, "Notification system enabled, continuing...");
 
-                    try
-                    {
-                        Main.LogEntry($"{methodName}", "Attempting to queue notification...");
-                        UnityMainThreadDispatcher.Instance().Enqueue(() =>
-                        {
-                            try
-                            {
-                                Main.LogEntry($"{methodName}", "Dispatching notification to main thread");
-                                string displayMessage = $"{chatter}: {text}";
-                                NewNotificationQueue["webSocketNotification"] = displayMessage;
-                                AttachNotification(displayMessage, "null");
-                                Main.LogEntry($"{methodName}", $"Successfully queued notification: {displayMessage}");
-                            }
-                            catch (Exception ex)
-                            {
-                                Main.LogEntry($"{methodName}", $"Error in main thread notification: {ex.Message}");
-                            }
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        Main.LogEntry($"{methodName}", $"Failed to queue notification: {ex.Message}");
-                    }
-                }
-                else
-                {
-                    Main.LogEntry($"{methodName}", "Invalid message: missing chatter or text");
-                }
+                    string displayMessage = $"{chatter}: {text}";
+                    NewNotificationQueue["webSocketNotification"] = displayMessage;
+                    AttachNotification(displayMessage, "null");
+                });
             }
             catch (Exception ex)
             {
-                Main.LogEntry($"{methodName}", $"Error processing notification: {ex.Message}");
-                Main.LogEntry($"{methodName}", $"Stack Trace: {ex.StackTrace}");
-            }
-        }
-
-        private static string ExtractValue(string json, string key)
-        {
-            try
-            {
-                switch (key)
-                {
-                    case "chatter_user_name":
-                        // Look for the specific path in the JSON
-                        int nameStart = json.IndexOf("\"chatter_user_name\":\"") + "\"chatter_user_name\":\"".Length;
-                        if (nameStart > 0)
-                        {
-                            int nameEnd = json.IndexOf("\"", nameStart);
-                            if (nameEnd > nameStart)
-                            {
-                                return json.Substring(nameStart, nameEnd - nameStart);
-                            }
-                        }
-                        break;
-
-                    case "chatter_user_id":
-                        // Look for the specific path in the JSON
-                        int idStart = json.IndexOf("\"chatter_user_id\":\"") + "\"chatter_user_id\":\"".Length;
-                        if (idStart > 0)
-                        {
-                            int idEnd = json.IndexOf("\"", idStart);
-                            if (idEnd > idStart)
-                            {
-                                return json.Substring(idStart, idEnd - idStart);
-                            }
-                        }
-                        break;
-
-                    case "text":
-                        // Text is nested inside the message object
-                        int textStart = json.IndexOf("\"message\":{\"text\":\"") + "\"message\":{\"text\":\"".Length;
-                        if (textStart > 0)
-                        {
-                            int textEnd = json.IndexOf("\"", textStart);
-                            if (textEnd > textStart)
-                            {
-                                return json.Substring(textStart, textEnd - textStart);
-                            }
-                        }
-                        break;
-                }
-                return string.Empty;
-            }
-            catch (Exception ex)
-            {
-                Main.LogEntry("ExtractValue", $"Error extracting {key}: {ex.Message}");
-                return string.Empty;
+                Main.LogEntry(methodName, $"Error processing notification: {ex.Message}");
+                Main.LogEntry(methodName, $"Stack Trace: {ex.StackTrace}");
             }
         }
 
         /// <summary>
-        /// Displays an in-game notification attached to a GameObject (if included).
+        /// Displays an in-game notification. May be called from any thread; the work is queued to the main thread.
         /// </summary>
         /// <param name="displayed_text">The text to display.</param>
-        /// <param name="object_name">The name of the GameObject to attempt to attach to.</param>
+        /// <param name="object_name">The name of a GameObject to look for, or "null" for none.</param>
         public static void AttachNotification(string displayed_text, string object_name)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            UnityMainThreadDispatcher.Instance().Enqueue(() => ShowNotificationOnMainThread(displayed_text, object_name));
+        }
+
+        /// <summary>
+        /// Performs the actual notification display. Must run on the Unity main thread.
+        /// </summary>
+        private static void ShowNotificationOnMainThread(string displayed_text, string object_name)
+        {
+            string methodName = "AttachNotification";
             Main.LogEntry(methodName, $"AttachNotification called with displayed_text: {displayed_text}, object_name: {object_name}");
 
-            // Find the object_name GameObject in the scene
-            GameObject found_object = GameObject.Find(object_name);
-            if (found_object != null)
+            if (!string.IsNullOrEmpty(object_name) && object_name != "null")
             {
-                Main.LogEntry(methodName, $"Found object: {found_object.name}");
-            }
-            else
-            {
-                // Main.LogEntry(methodName, "Object not found");
+                GameObject found_object = GameObject.Find(object_name);
+                if (found_object != null)
+                {
+                    Main.LogEntry(methodName, $"Found object: {found_object.name}");
+                }
             }
 
-            // Find NotificationManager in the scene
+            // Find the game's NotificationManager in the scene
             DV.UIFramework.NotificationManager notificationManager = UnityEngine.Object.FindObjectOfType<DV.UIFramework.NotificationManager>();
             if (notificationManager == null)
             {
                 Main.LogEntry(methodName, "NotificationManager not found in the scene.");
                 return;
             }
-            else
-            {
-                Main.LogEntry(methodName, "NotificationManager found in the scene.");
-            }
 
-            // Ensure displayed_text is a string with only standard alphanumeric characters and punctuation, no longer than 80 characters
+            // Ensure displayed_text contains only standard alphanumeric characters and punctuation, no longer than 80 characters
             if (displayed_text.Length > 80)
             {
                 displayed_text = displayed_text.Substring(0, 80);
@@ -298,28 +191,98 @@ namespace TwitchChat
             }
 
             displayed_text = new string(displayed_text.Where(c => char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsWhiteSpace(c)).ToArray());
-            Main.LogEntry(methodName, $"Sanitized displayed_text: {displayed_text}");
 
             try
             {
-                // Display a notification, attached to the found_object if it's not null
-                Main.LogEntry(methodName, "Attempting to show notification");
-                var notification = notificationManager.ShowNotification(
-                    displayed_text,                     // Text
-                    null,                               // Localization parameters
-                    Settings.Instance.notificationDuration,  // Duration
-                    false,                              // Clear existing notifications
-                    // found_object?.transform,         // Attach to GameObject if not null
-                    null,                               // Temp force null for GameObject.transform
-                    false,                              // Localize
-                    false                               // Target UI
-                );
-                Main.LogEntry(methodName, "Notification shown successfully");
+                GameObject? notification;
+                try
+                {
+                    notification = ShowNotificationDirect(notificationManager, displayed_text, Settings.Instance.notificationDuration);
+                }
+                catch (MissingMethodException mmEx)
+                {
+                    // The game changed the ShowNotification signature (this is what broke v3.1.0). Fall back to a late-bound call.
+                    Main.LogEntry(methodName, $"Game notification API signature changed ({mmEx.Message}); using reflection fallback.");
+                    notification = ShowNotificationViaReflection(notificationManager, displayed_text, Settings.Instance.notificationDuration);
+                }
+
+                Main.LogEntry(methodName, notification != null ? "Notification shown successfully" : "Notification call returned nothing");
             }
             catch (Exception ex)
             {
                 Main.LogEntry(methodName, $"Error showing notification and text: {displayed_text}\nException: {ex.Message}\nStack Trace: {ex.StackTrace}");
             }
+        }
+
+        /// <summary>
+        /// Direct, compile-time bound call to the game's notification API.
+        /// Kept in its own non-inlined method so a signature mismatch surfaces as a catchable
+        /// MissingMethodException at this call site instead of taking down the caller.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static GameObject? ShowNotificationDirect(DV.UIFramework.NotificationManager manager, string text, float duration)
+        {
+            return manager.ShowNotification(
+                text,       // Text
+                null,       // Localization parameters
+                duration,   // Duration
+                false,      // Clear existing notifications
+                null,       // Point at transform
+                false,      // Localize
+                false       // Target UI
+            );
+        }
+
+        /// <summary>
+        /// Late-bound call to ShowNotification that fills every parameter the current game build declares,
+        /// using the game's own defaults for anything this mod does not set.
+        /// </summary>
+        private static GameObject? ShowNotificationViaReflection(DV.UIFramework.NotificationManager manager, string text, float duration)
+        {
+            MethodInfo? method = typeof(DV.UIFramework.NotificationManager)
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Where(m => m.Name == "ShowNotification")
+                .OrderByDescending(m => m.GetParameters().Length)
+                .FirstOrDefault();
+
+            if (method == null)
+            {
+                Main.LogEntry("ShowNotificationViaReflection", "ShowNotification method not found on the game's NotificationManager.");
+                return null;
+            }
+
+            ParameterInfo[] parameters = method.GetParameters();
+            object?[] args = new object?[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                ParameterInfo parameter = parameters[i];
+                Type parameterType = parameter.ParameterType;
+                object? value = parameter.HasDefaultValue ? parameter.DefaultValue : null;
+
+                if (value == null && parameterType.IsValueType)
+                {
+                    value = Activator.CreateInstance(parameterType);
+                }
+                else if (value != null && parameterType.IsEnum && !parameterType.IsInstanceOfType(value))
+                {
+                    value = Enum.ToObject(parameterType, value);
+                }
+
+                switch (parameter.Name)
+                {
+                    case "locKey": value = text; break;
+                    case "locParams": value = null; break;
+                    case "duration": value = duration; break;
+                    case "clearExisting": value = false; break;
+                    case "pointAt": value = null; break;
+                    case "localize": value = false; break;
+                    case "targetIsUI": value = false; break;
+                }
+
+                args[i] = value;
+            }
+
+            return method.Invoke(manager, args) as GameObject;
         }
     }
 }

--- a/PanelHost.cs
+++ b/PanelHost.cs
@@ -1,0 +1,125 @@
+using DV.CabControls;
+using TwitchChat.PanelDisplays;
+using TwitchChat.PanelMenus;
+using UnityEngine;
+
+namespace TwitchChat
+{
+    /// <summary>
+    /// A surface that carries the mod's full panel stack: one world-space canvas plus an instance of
+    /// every menu and display panel. Concrete hosts decide where the canvas lives (a license paper,
+    /// the locomotive cab, or the player's wrist) and where the active panel choice is persisted.
+    /// </summary>
+    public abstract class PanelHost
+    {
+        public string Name { get; }
+        public GameObject? MenuCanvas { get; set; }
+
+        // Panel Menus
+        public MainPanel? MainPanel { get; set; }
+        public StatusPanel? StatusPanel { get; set; }
+        public NotificationsPanel? NotificationsPanel { get; set; }
+        public StandardMessagesPanel? StandardMessagesPanel { get; set; }
+        public CommandMessagesPanel? CommandMessagesPanel { get; set; }
+        public TimedMessagesPanel? TimedMessagesPanel { get; set; }
+        public Config1Panel? Config1Panel { get; set; }
+        public Config2Panel? Config2Panel { get; set; }
+        public DebugPanel? DebugPanel { get; set; }
+
+        // Panel Displays
+        public LargeDisplayPanel? LargeDisplayPanel { get; set; }
+        public MediumDisplayPanel? MediumDisplayPanel { get; set; }
+        public SmallDisplayPanel? SmallDisplayPanel { get; set; }
+        public WideDisplayPanel? WideDisplayPanel { get; set; }
+
+        protected PanelHost(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>Name of the panel currently shown on this host. Persisted in settings.</summary>
+        public abstract string ActivePanel { get; set; }
+    }
+
+    /// <summary>
+    /// Legacy host: the canvas rides on one of the player's license papers and hides the printed page.
+    /// </summary>
+    public class LicenseHost : PanelHost
+    {
+        /// <summary>Slot in <see cref="Settings.activePanels"/> that remembers this host's panel.</summary>
+        public int LicenseIndex { get; }
+
+        /// <summary>The prefab name the game reports for this license item; identical to <see cref="PanelHost.Name"/>.</summary>
+        public string PrefabName => Name;
+
+        /// <summary>The live item component, or null until the item has been found in the world.</summary>
+        public ItemBase? Item { get; set; }
+
+        /// <summary>The license GameObject the canvas follows.</summary>
+        public GameObject? LicenseObject { get; set; }
+
+        /// <summary>The printed page renderer that is kept hidden while the canvas covers it.</summary>
+        public Renderer? PaperRenderer { get; set; }
+
+        /// <summary>Fallback paper object for prefabs without a Page component.</summary>
+        public GameObject? PaperObject { get; set; }
+
+        public bool AttachedToStickyTape { get; set; }
+        public GameObject? StickyTapeBase { get; set; }
+
+        public LicenseHost(string prefabName, int index) : base(prefabName)
+        {
+            LicenseIndex = index;
+        }
+
+        public override string ActivePanel
+        {
+            get
+            {
+                string[] panels = Settings.Instance.activePanels;
+                return LicenseIndex < panels.Length && !string.IsNullOrEmpty(panels[LicenseIndex]) ? panels[LicenseIndex] : "Main";
+            }
+            set
+            {
+                if (LicenseIndex < Settings.Instance.activePanels.Length)
+                {
+                    Settings.Instance.activePanels[LicenseIndex] = value;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Host parented to the current locomotive's interior so it rides along with the cab.
+    /// </summary>
+    public class CabDisplayHost : PanelHost
+    {
+        /// <summary>True once the display has been placed (or restored from a saved pose) on a car.</summary>
+        public bool Placed { get; set; }
+
+        public CabDisplayHost() : base("CabDisplay") { }
+
+        public override string ActivePanel
+        {
+            get => string.IsNullOrEmpty(Settings.Instance.cabDisplayPanel) ? "Main" : Settings.Instance.cabDisplayPanel;
+            set => Settings.Instance.cabDisplayPanel = value;
+        }
+    }
+
+    /// <summary>
+    /// Host parented to a VR controller so it sits on the player's forearm like a watch.
+    /// </summary>
+    public class WristPanelHost : PanelHost
+    {
+        /// <summary>Whether the canvas is currently attached to the left hand (false = right hand).</summary>
+        public bool AttachedToLeftHand { get; set; }
+
+        public WristPanelHost() : base("WristPanel") { }
+
+        public override string ActivePanel
+        {
+            get => string.IsNullOrEmpty(Settings.Instance.wristPanel) ? "Main" : Settings.Instance.wristPanel;
+            set => Settings.Instance.wristPanel = value;
+        }
+    }
+}

--- a/PanelMenus/CommandMessages.cs
+++ b/PanelMenus/CommandMessages.cs
@@ -57,7 +57,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             commandsMessageEnabled.onValueChanged.AddListener((value) => {
                 Settings.Instance.commandsMessageEnabled = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateCommandsMessageToggles(value);
             });
 
@@ -76,7 +76,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             infoMessageEnabled.onValueChanged.AddListener((value) => {
                 Settings.Instance.infoMessageEnabled = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateInfoMessageToggles(value);
             });
 

--- a/PanelMenus/Config1.cs
+++ b/PanelMenus/Config1.cs
@@ -46,7 +46,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.panelColor;
                 newColor.r = value / 100f;
                 Settings.Instance.panelColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
             });
 
@@ -58,7 +58,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.panelColor;
                 newColor.g = value / 100f;
                 Settings.Instance.panelColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
             });
 
@@ -70,7 +70,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.panelColor;
                 newColor.b = value / 100f;
                 Settings.Instance.panelColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
             });
 
@@ -82,7 +82,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.panelColor;
                 newColor.a = value / 100f;
                 Settings.Instance.panelColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
             });
         }
@@ -103,7 +103,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.sectionColor;
                 newColor.r = value / 100f;
                 Settings.Instance.sectionColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
             });
 
@@ -115,7 +115,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.sectionColor;
                 newColor.g = value / 100f;
                 Settings.Instance.sectionColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
             });
 
@@ -127,7 +127,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.sectionColor;
                 newColor.b = value / 100f;
                 Settings.Instance.sectionColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
             });
 
@@ -139,7 +139,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.sectionColor;
                 newColor.a = value / 100f;
                 Settings.Instance.sectionColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
             });
         }

--- a/PanelMenus/Config2.cs
+++ b/PanelMenus/Config2.cs
@@ -45,7 +45,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.buttonColor;
                 newColor.r = value / 100f;
                 Settings.Instance.buttonColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllButtonColors();
             });
 
@@ -57,7 +57,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.buttonColor;
                 newColor.g = value / 100f;
                 Settings.Instance.buttonColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllButtonColors();
             });
 
@@ -69,7 +69,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.buttonColor;
                 newColor.b = value / 100f;
                 Settings.Instance.buttonColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllButtonColors();
             });
 
@@ -81,7 +81,7 @@ namespace TwitchChat.PanelMenus
                 Color newColor = Settings.Instance.buttonColor;
                 newColor.a = value / 100f;
                 Settings.Instance.buttonColor = newColor;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllButtonColors();
             });
         }
@@ -93,21 +93,21 @@ namespace TwitchChat.PanelMenus
             // Reset Panel Color button
             PanelConstructor.Button.Create(resetSection.transform, "Reset Panel Color", 80, 35, clicked: () => {
                 Settings.Instance.panelColor = new Color(0, 0, 0, 0.3f);
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
             });
             
             // Reset Section Color button
             PanelConstructor.Button.Create(resetSection.transform, "Reset Section Color", 80, 60, clicked: () => {
                 Settings.Instance.sectionColor = new Color(0, 0, 0, 0.1f);
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
             });
             
             // Reset Button Color button
             PanelConstructor.Button.Create(resetSection.transform, "Reset Button Color", 80, 85, clicked: () => {
                 Settings.Instance.buttonColor = new Color(0, 0, 0, 0.5f);
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllButtonColors();
                 
                 // Update sliders to reflect new values
@@ -125,7 +125,7 @@ namespace TwitchChat.PanelMenus
                 Settings.Instance.buttonColor = new Color(0, 0, 0, 0.5f);
                 
                 // Update all UI elements with new colors
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllPanelBackgrounds();
                 MenuManager.Instance.UpdateAllSectionBackgrounds();
                 MenuManager.Instance.UpdateAllButtonColors();

--- a/PanelMenus/Debug.cs
+++ b/PanelMenus/Debug.cs
@@ -72,7 +72,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             processOwn.onValueChanged.AddListener((value) => {
                 Settings.Instance.processOwn = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllProcessOwnToggles(value);
             });
 
@@ -88,7 +88,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             processDuplicates.onValueChanged.AddListener((value) => {
                 Settings.Instance.processDuplicates = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllProcessDuplicatesToggles(value);
             });
         }
@@ -105,7 +105,7 @@ namespace TwitchChat.PanelMenus
             
             // Update settings
             Settings.Instance.debugLevel = (DebugLevel)nextLevel;
-            Settings.Instance.Save(Main.ModEntry);
+            Settings.Instance.RequestSave();
 
             // Update button text
             if (debugLevelButton != null)

--- a/PanelMenus/Main.cs
+++ b/PanelMenus/Main.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -10,16 +9,16 @@ namespace TwitchChat.PanelMenus
     /// </summary>
     public class MainPanel : PanelConstructor.BasePanel
     {
-        private readonly License menuIndex;
+        private readonly PanelHost? host;
 
         /// <summary>
         /// Initializes a new instance of the MainPanel.
         /// </summary>
         /// <param name="parent">The parent transform this panel will be attached to.</param>
-        /// <param name="index">The license index for the menu.</param>
-        public MainPanel(Transform parent, License index) : base(parent)
+        /// <param name="host">The host this menu belongs to, or null for the hidden template copy.</param>
+        public MainPanel(Transform parent, PanelHost? host) : base(parent)
         {
-            menuIndex = index;
+            this.host = host;
             CreateMainMenu();
         }
 
@@ -35,37 +34,55 @@ namespace TwitchChat.PanelMenus
             CreateMenuButton("Command Messages", 110);
             CreateMenuButton("Timed Messages", 135);
             CreateMenuButton("Debug", 160);
-            
+
             // Config buttons side by side
             CreateMenuButton("Config1", 185, -35); // Offset to the left
             CreateMenuButton("Config2", 185, 35);  // Offset to the right
-            
+
             // Display buttons
             CreateMenuButton("Wide Display", 210);
             CreateMenuButton("Large Display", 235);
             CreateMenuButton("Medium Display", 260);
             CreateMenuButton("Small Display", 285);
+
+            // Cab display controls side by side
+            CreateActionButton("Place Display", 310, -42, () => MenuManager.Instance.PlaceCabDisplay());
+            CreateActionButton("Toggle Display", 310, 42, () => MenuManager.Instance.ToggleCabDisplay());
         }
 
         /// <summary>
-        /// Creates a navigation button with the specified text and position.
+        /// Creates a navigation button that switches this host to the named panel.
         /// </summary>
-        /// <param name="text">The button text.</param>
+        /// <param name="text">The button text, which is also the panel name.</param>
         /// <param name="verticalPosition">The vertical position of the button.</param>
         /// <param name="horizontalOffset">The horizontal offset of the button.</param>
         private void CreateMenuButton(string text, int verticalPosition, float horizontalOffset = 0)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
-            
+            CreateActionButton(text, verticalPosition, horizontalOffset, () =>
+            {
+                if (host != null)
+                {
+                    MenuManager.Instance.OnPanelButtonClicked(text, host);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Creates a button that runs an arbitrary action.
+        /// </summary>
+        private void CreateActionButton(string text, int verticalPosition, float horizontalOffset, System.Action action)
+        {
+            string methodName = "MainPanel";
             Main.LogEntry(methodName, $"Creating button: {text}");
             Button button = PanelConstructor.Button.Create(
-                panelObject.transform, 
-                text, 
+                panelObject.transform,
+                text,
                 (int)(100 + horizontalOffset),  // Add horizontal offset to base position
                 verticalPosition,
-                clicked: () => {
+                clicked: () =>
+                {
                     Main.LogEntry(methodName, $"Button clicked: {text}");
-                    MenuManager.Instance.OnPanelButtonClicked(text, menuIndex);
+                    action();
                 }
             );
         }

--- a/PanelMenus/Notifications.cs
+++ b/PanelMenus/Notifications.cs
@@ -63,7 +63,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             notificationsEnabled.onValueChanged.AddListener((value) => {
                 Settings.Instance.notificationsEnabled = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllNotificationToggles(value);
             });
 
@@ -78,7 +78,7 @@ namespace TwitchChat.PanelMenus
             
             notificationDuration.onValueChanged.AddListener((value) => {
                 Settings.Instance.notificationDuration = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllNotificationDurations(value);
             });
 

--- a/PanelMenus/StandardMessages.cs
+++ b/PanelMenus/StandardMessages.cs
@@ -65,7 +65,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             connectMessageEnabled.onValueChanged.AddListener((value) => {
                 Settings.Instance.connectMessageEnabled = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllConnectMessageEnabledToggles(value);
             });
 
@@ -84,7 +84,7 @@ namespace TwitchChat.PanelMenus
             // Add listener after toggle creation
             disconnectMessageEnabled.onValueChanged.AddListener((value) => {
                 Settings.Instance.disconnectMessageEnabled = value;
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllDisconnectMessageEnabledToggles(value);
             });
 
@@ -105,7 +105,7 @@ namespace TwitchChat.PanelMenus
         //     // // Add listener after toggle creation
         //     // newFollowerMessageEnabled.onValueChanged.AddListener((value) => {
         //     //     Settings.Instance.newFollowerMessageEnabled = value;
-        //     //     Settings.Instance.Save(Main.ModEntry);
+        //     //     Settings.Instance.RequestSave();
         //     //     MenuManager.Instance.UpdateAllNewFollowerMessageEnabledToggles(value);
         //     // });
 
@@ -125,7 +125,7 @@ namespace TwitchChat.PanelMenus
         //     // // Add listener after toggle creation
         //     // newSubscriberMessageEnabled.onValueChanged.AddListener((value) => {
         //     //     Settings.Instance.newSubscriberMessageEnabled = value;
-        //     //     Settings.Instance.Save(Main.ModEntry);
+        //     //     Settings.Instance.RequestSave();
         //     //     MenuManager.Instance.UpdateAllNewSubscriberMessageEnabledToggles(value);
         //     // });
 

--- a/PanelMenus/Status.cs
+++ b/PanelMenus/Status.cs
@@ -79,7 +79,7 @@ namespace TwitchChat.PanelMenus
             Color.white,
             () => {
                 if (WebSocketManager.IsConnectionHealthy)
-                _ = WebSocketManager.DisconnectFromoWebSocket();
+                _ = WebSocketManager.DisconnectFromWebSocket();
                 else
                 _ = WebSocketManager.ConnectToWebSocket();
             },

--- a/PanelMenus/TimedMessages.cs
+++ b/PanelMenus/TimedMessages.cs
@@ -45,7 +45,7 @@ namespace TwitchChat.PanelMenus
             timedMessageSystemToggle.onValueChanged.AddListener((value) => {
                 Settings.Instance.timedMessageSystemToggle = value;
                 AutomatedMessages.ToggleTimedMessages();
-                Settings.Instance.Save(Main.ModEntry);
+                Settings.Instance.RequestSave();
                 MenuManager.Instance.UpdateAllTimedMessageToggles(value);
             });
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,22 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 
 ### Display and Menu Panel Setup
 
-- Menus automatically 'replace' the following licenses:
--- LicenseTrainDriver - Automatically given at start of a new game
--- LicenseShunting - Automatically given at start of a new game
--- LicenseLocomotiveDE2 - Automatically given at start of a new game
--- LicenseMuseumCitySouth - Purchase/own the the 'Museum' license
--- LicenseFreightHaul - Purchase/own the Freight Haul 1 license
--- LicenseDispatcher1 - Purchase/own the Dispatcher license
+The menus and chat displays live on world-space panels. There are three kinds of panel host:
 
-- Each menu is an exact duplicate, though you can show different panels on each
+- **Cab display** - a panel parented to the locomotive you are in, so it rides along with the cab
+-- Press the place key (default F7), or use the "Place Display" button on any Main panel, and the panel appears where you are looking
+-- The position is remembered per locomotive type and restored automatically the next time you board that type
+-- The toggle key (default F8), or the "Toggle Display" button, hides and shows it without moving it
+-- Keys, placement distance and scale are set in the Unity Mod Manager menu
+- **Wrist panel** (VR only) - a smaller copy of the menus attached to a controller, glance at it like a watch
+-- Choose the hand, size, offset and rotation in the Unity Mod Manager menu; changes apply live
+-- Its "Place Display" button is the VR way to summon the cab display without a keyboard
+- **License papers** (legacy mode, can be turned off in the Unity Mod Manager menu) - menus replace the following licenses:
+-- LicenseTrainDriver, LicenseShunting, LicenseLocomotiveDE2 - given at the start of a new game
+-- LicenseMuseumCitySouth, LicenseFreightHaul, LicenseDispatcher1 - purchase/own the license
+-- As these menus ride on licenses, they can be attached to sticky tape anywhere sticky tape can be placed
+
+- Every host shows the same panels and remembers which panel it last showed
 - Display Panels:
 -- Wide - Little wider than the large, but about 1/3 in height
 -- Large - Approx same size as the DE2 back window
@@ -56,16 +63,15 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 -- Small - Same size as the license
 - Config Panels
 -- Config1 - Customize background panel and section coloring
--- Config2 - Customize button coloring and reset color cusotmizations
+-- Config2 - Customize button coloring and reset color customizations
 - Menu Panels
--- Main - Access all other panels from here
--- Notifications - Enable/Disable the notification popups when new messges are received and set duration
+-- Main - Access all other panels from here, plus the Place Display and Toggle Display buttons
+-- Notifications - Enable/Disable the notification popups when new messages are received and set duration
 -- Standard Messages - Enable/Disable your automatic Connect/Disconnect messages
 -- Command Messages - Enable/Disable the !info and !command ...commands
 -- Timed Messages - Enable/Disable the timed messages system
 -- Debug - Set debug level, several 'debug and testing' related buttons
 
-- As these menus replaced license, they can be 'attached' to sticky tape **ANYWHERE** (that sticky tape can be placed)
 - Buttons can be interacted with in both VR and non-VR modes
 - Top left panel buttons will 'minimize' the displayed panel
 - Top right panel buttons will return to the 'Main' panel (does nothing 'on' the Main panel)
@@ -110,6 +116,23 @@ Access advanced options by expanding the "Debug and Troubleshooting" section in 
 - [GitHub Repository](https://github.com/Nightwind416/Derail-Valley-Twitch-Chat-Mod)
 
 ## Version History
+
+### 3.3.0 (September 4, 2026)
+
+- New cab display: a panel placed where you look that rides along with the locomotive and remembers its position per locomotive type
+- New wrist panel for VR: the menus on your forearm, including a button to summon the cab display
+- License paper menus are now an optional legacy mode. Licenses are found through the game's item system instead of by object name, so they work again on current game builds
+- Unity Mod Manager menu gains a section for the hotkeys, placement distance, and wrist panel tuning
+
+### 3.2.0 (September 4, 2026)
+
+- Fixed the mod failing to enable on current game builds (the game's notification API gained new optional parameters; the mod now tolerates such changes)
+- WebSocket messages are reassembled from all frames, so long chat messages are no longer truncated or dropped
+- Twitch "session reconnect" requests are honoured, and lost connections retry with backoff instead of giving up
+- Connect/disconnect chat announcements are only sent for manual connects and disconnects, not automatic reconnects
+- The "Last Message Sent" status for timed messages now updates
+- Settings changes made from the in-game panels are written to disk after a short delay instead of on every slider tick
+- Received chat messages are now written to the Messages log
 
 ### 3.1.0 (January 16,2025)
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -53,6 +53,25 @@ namespace TwitchChat
         public Color panelColor = new(0, 0, 0, 0.3f);
         public Color sectionColor = new(0, 0, 0, 0.1f);
         public Color buttonColor = new(0, 0, 0, 0.5f);
+
+        // Cab Display and Wrist Panel Settings
+        public bool licensePanelsEnabled = true;
+        public string cabDisplayPanel = "Main";
+        public bool cabDisplayVisible = true;
+        public float cabDisplayDistance = 0.7f;
+        public float cabDisplayScale = 1.0f;
+        public string placeDisplayKey = "F7";
+        public string toggleDisplayKey = "F8";
+        public List<CabDisplayPose> cabDisplayPoses = new();
+        public bool wristPanelEnabled = true;
+        public string wristPanel = "Main";
+        public bool wristPanelOnLeftHand = true;
+        public float wristPanelScale = 0.6f;
+        public Vector3 wristPanelOffset = DefaultWristOffset;
+        public Vector3 wristPanelRotation = DefaultWristRotation;
+
+        public static readonly Vector3 DefaultWristOffset = new(0f, 0.04f, -0.10f);
+        public static readonly Vector3 DefaultWristRotation = new(90f, 0f, 0f);
         
         // Standard Messages Settings
         public bool connectMessageEnabled = true;
@@ -141,6 +160,19 @@ namespace TwitchChat
                 "Primary" => Color.red,
                 _ => Color.white
             };
+        }
+
+        /// <summary>
+        /// Draws a labelled horizontal slider with its current value and returns the (possibly changed) value.
+        /// </summary>
+        private static float SliderRow(string label, float value, float min, float max, string format)
+        {
+            GUILayout.BeginHorizontal();
+                GUILayout.Label(label, GUILayout.Width(160));
+                float result = GUILayout.HorizontalSlider(value, min, max, GUILayout.Width(200));
+                GUILayout.Label(result.ToString(format), GUILayout.Width(60));
+            GUILayout.EndHorizontal();
+            return result;
         }
 
         /// <summary>
@@ -348,6 +380,57 @@ namespace TwitchChat
 
             // GUILayout.Space(10);
             
+            // Cab Display and Wrist Panel Section
+            GUILayout.BeginVertical(GUI.skin.box);
+                GUILayout.Label("Cab Display and Wrist Panel");
+                GUILayout.Space(5);
+                GUILayout.BeginHorizontal();
+                    if (GUILayout.Button("Place Cab Display In Front Of Me", GUILayout.Width(230)))
+                    {
+                        MenuManager.Instance.PlaceCabDisplay();
+                    }
+                    if (GUILayout.Button(cabDisplayVisible ? "Hide Cab Display" : "Show Cab Display", GUILayout.Width(150)))
+                    {
+                        MenuManager.Instance.ToggleCabDisplay();
+                    }
+                GUILayout.EndHorizontal();
+                GUILayout.BeginHorizontal();
+                    GUILayout.Label("Place key:", GUILayout.Width(160));
+                    placeDisplayKey = GUILayout.TextField(placeDisplayKey, GUILayout.Width(80));
+                    GUILayout.Label("Toggle key:", GUILayout.Width(80));
+                    toggleDisplayKey = GUILayout.TextField(toggleDisplayKey, GUILayout.Width(80));
+                    GUILayout.Label("(Unity KeyCode names, for example F7 or Keypad1)");
+                GUILayout.EndHorizontal();
+                cabDisplayDistance = SliderRow("Placement distance (m)", cabDisplayDistance, 0.3f, 2.0f, "0.00");
+                cabDisplayScale = SliderRow("Cab display scale", cabDisplayScale, 0.5f, 2.0f, "0.00");
+                GUILayout.Space(5);
+                licensePanelsEnabled = GUILayout.Toggle(licensePanelsEnabled, " Also show the menus on the six license papers (legacy mode)");
+                GUILayout.Space(5);
+                wristPanelEnabled = GUILayout.Toggle(wristPanelEnabled, " Wrist panel (VR only)");
+                GUILayout.BeginHorizontal();
+                    GUILayout.Label("Wrist panel hand:", GUILayout.Width(160));
+                    if (GUILayout.Button(wristPanelOnLeftHand ? "Left" : "Right", GUILayout.Width(80)))
+                    {
+                        wristPanelOnLeftHand = !wristPanelOnLeftHand;
+                    }
+                GUILayout.EndHorizontal();
+                wristPanelScale = SliderRow("Wrist panel scale", wristPanelScale, 0.2f, 1.5f, "0.00");
+                wristPanelOffset.x = SliderRow("Wrist offset X (m)", wristPanelOffset.x, -0.3f, 0.3f, "0.000");
+                wristPanelOffset.y = SliderRow("Wrist offset Y (m)", wristPanelOffset.y, -0.3f, 0.3f, "0.000");
+                wristPanelOffset.z = SliderRow("Wrist offset Z (m)", wristPanelOffset.z, -0.3f, 0.3f, "0.000");
+                wristPanelRotation.x = SliderRow("Wrist rotation X (deg)", wristPanelRotation.x, -180f, 180f, "0");
+                wristPanelRotation.y = SliderRow("Wrist rotation Y (deg)", wristPanelRotation.y, -180f, 180f, "0");
+                wristPanelRotation.z = SliderRow("Wrist rotation Z (deg)", wristPanelRotation.z, -180f, 180f, "0");
+                if (GUILayout.Button("Reset wrist panel to defaults", GUILayout.Width(200)))
+                {
+                    wristPanelOffset = DefaultWristOffset;
+                    wristPanelRotation = DefaultWristRotation;
+                    wristPanelScale = 0.6f;
+                }
+            GUILayout.EndVertical();
+
+            GUILayout.Space(10);
+
             // Debug Settings Section
             GUILayout.BeginVertical(GUI.skin.box);
                 GUILayout.Label("Debug Level");
@@ -382,6 +465,33 @@ namespace TwitchChat
             _ = this;
         }
 
+        // Deferred saving: panel sliders fire on every tick, so writes are coalesced and flushed after a short quiet period.
+        private bool saveRequested;
+        private DateTime saveRequestedAt;
+        private static readonly TimeSpan saveDelay = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Marks the settings as changed. The file is written by <see cref="FlushPendingSave"/> once changes stop for a second.
+        /// Use this from in-game panel controls; use <see cref="Save(UnityModManager.ModEntry)"/> when the write must happen now.
+        /// </summary>
+        public void RequestSave()
+        {
+            saveRequested = true;
+            saveRequestedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Writes pending changes to disk. Called every frame by the MenuManager; pass true to write immediately.
+        /// </summary>
+        /// <param name="force">Write now even if changes are still arriving.</param>
+        public void FlushPendingSave(bool force = false)
+        {
+            if (!saveRequested) return;
+            if (!force && DateTime.UtcNow - saveRequestedAt < saveDelay) return;
+            saveRequested = false;
+            Save(Main.ModEntry);
+        }
+
         /// <summary>
         /// Default constructor for Settings class
         /// </summary>
@@ -408,6 +518,17 @@ namespace TwitchChat
         public override string GetPath(UnityModManager.ModEntry modEntry) {
             return Path.Combine(modEntry.Path, "Settings.xml");
         }
+    }
+
+    /// <summary>
+    /// Where the cab display sits inside one locomotive type, stored relative to the car interior transform.
+    /// </summary>
+    [Serializable]
+    public class CabDisplayPose
+    {
+        public string carId = string.Empty;
+        public Vector3 localPosition;
+        public Vector3 localEuler;
     }
 
     /// <summary>

--- a/TwitchChat.csproj
+++ b/TwitchChat.csproj
@@ -9,9 +9,9 @@
 		<DerailValleyManagedAssets>D:\SteamLibrary\steamapps\common\Derail Valley\DerailValley_Data\Managed\</DerailValleyManagedAssets> <!-- Change to local game install path during build -->
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 		<DebugType>none</DebugType>
-		<ModVersion>3.1.0</ModVersion>
+		<ModVersion>3.3.0</ModVersion>
 		<ModAuthor>Nightwind416</ModAuthor>
-		<GameVersion>build 99.3</GameVersion>
+		<GameVersion>build 99</GameVersion>
 		<EntryMethod>TwitchChat.Main.Load</EntryMethod>
 		<ManagerVersion>0.27.3</ManagerVersion>
 		<ModHomepage>https://www.nexusmods.com/derailvalley/mods/1069</ModHomepage>
@@ -60,6 +60,22 @@
 			<HintPath>$(DerailValleyManagedAssets)DV.Utils.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="DV.ThingTypes">
+			<HintPath>$(DerailValleyManagedAssets)DV.ThingTypes.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="WorldStreamer">
+			<HintPath>$(DerailValleyManagedAssets)WorldStreamer.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="VRTK">
+			<HintPath>$(DerailValleyManagedAssets)VRTK.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Newtonsoft.Json">
+			<HintPath>$(DerailValleyManagedAssets)Newtonsoft.Json.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="UnityEngine.UI">
 			<HintPath>$(DerailValleyManagedAssets)UnityEngine.UI.dll</HintPath>
 			<Private>false</Private>
@@ -74,10 +90,6 @@
 		</Reference>
 		<Reference Include="UnityEngine.PhysicsModule">
 			<HintPath>$(DerailValleyManagedAssets)UnityEngine.PhysicsModule.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine.EventSystems">
-			<HintPath>$(DerailValleyManagedAssets)UnityEngine.EventSystems.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 	</ItemGroup>

--- a/TwitchEventHandler.cs
+++ b/TwitchEventHandler.cs
@@ -3,6 +3,8 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace TwitchChat
 {
@@ -21,7 +23,7 @@ namespace TwitchChat
     {
         /// <summary>Shared HttpClient instance for API requests</summary>
         public static readonly HttpClient httpClient = new();
-        
+
         /// <summary>Current user's Twitch ID</summary>
         public static string user_id = string.Empty;
 
@@ -31,55 +33,39 @@ namespace TwitchChat
         public static async Task GetUserID()
         {
             string methodName = "GetUserID";
-            
+
             byte[] tokenBytes = Convert.FromBase64String(Settings.Instance.EncodedOAuthToken);
-            _ = Encoding.UTF8.GetString(tokenBytes);
             string access_token = Encoding.UTF8.GetString(tokenBytes);
-            
+
             Main.LogEntry(methodName, "Adding Authorization and Client-Id headers.");
             httpClient.DefaultRequestHeaders.Clear();
             httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {access_token}");
             httpClient.DefaultRequestHeaders.Add("Client-Id", GetClientId());
-        
+
             Main.LogEntry(methodName, "Sending GET request to https://api.twitch.tv/helix/users.");
-            var response = await httpClient.GetAsync($"https://api.twitch.tv/helix/users?login={Settings.Instance.twitchUsername}");
+            var response = await httpClient.GetAsync($"https://api.twitch.tv/helix/users?login={Uri.EscapeDataString(Settings.Instance.twitchUsername)}");
             Main.LogEntry(methodName, $"Response status code: {response.StatusCode}");
-        
+
             if (response.StatusCode == HttpStatusCode.BadRequest)
             {
                 var errorContent = await response.Content.ReadAsStringAsync();
                 Main.LogEntry(methodName, $"Response error content: {errorContent}");
             }
-        
+
             response.EnsureSuccessStatusCode();
-        
+
             var content = await response.Content.ReadAsStringAsync();
             Main.LogEntry(methodName, $"Response content: {content}");
-            
-            // Replace JsonDocument parsing with string parsing
-            string? lookup_id = null;
-            if (content.Contains("\"id\":\""))
+
+            string? lookup_id = (string?)JObject.Parse(content).SelectToken("data[0].id");
+
+            if (!string.IsNullOrEmpty(lookup_id))
             {
-                int startIndex = content.IndexOf("\"id\":\"") + 6;
-                int endIndex = content.IndexOf("\"", startIndex);
-                if (startIndex > 5 && endIndex > startIndex)
-                {
-                    lookup_id = content.Substring(startIndex, endIndex - startIndex);
-                }
-            }
-        
-            if (lookup_id == null)
-            {
-                Main.LogEntry(methodName, "User ID is null.");
-            }
-        
-            if (lookup_id != null)
-            {
-                user_id = lookup_id;
+                user_id = lookup_id!;
             }
             else
             {
-                Main.LogEntry(methodName, "Failed to retrieve user ID.");
+                Main.LogEntry(methodName, "Failed to retrieve user ID (no user returned for that login name).");
             }
             Main.LogEntry(methodName, $"User ID: {user_id}");
         }
@@ -93,16 +79,15 @@ namespace TwitchChat
             try
             {
                 byte[] tokenBytes = Convert.FromBase64String(Settings.Instance.EncodedOAuthToken);
-                _ = Encoding.UTF8.GetString(tokenBytes);
                 string access_token = Encoding.UTF8.GetString(tokenBytes);
-                
+
                 Main.LogEntry(methodName, "Adding Authorization and Client-Id headers.");
                 httpClient.DefaultRequestHeaders.Clear();
                 httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {access_token}");
                 httpClient.DefaultRequestHeaders.Add("Client-Id", GetClientId());
 
                 Main.LogEntry(methodName, "Sending GET request to https://api.twitch.tv/helix/users.");
-                var userResponse = await httpClient.GetAsync($"https://api.twitch.tv/helix/users?login={Settings.Instance.twitchUsername}");
+                var userResponse = await httpClient.GetAsync($"https://api.twitch.tv/helix/users?login={Uri.EscapeDataString(Settings.Instance.twitchUsername)}");
                 Main.LogEntry(methodName, $"User response status code: {userResponse.StatusCode}");
 
                 if (userResponse.StatusCode == HttpStatusCode.Unauthorized)
@@ -161,26 +146,40 @@ namespace TwitchChat
         {
             string methodName = "SendMessage";
             Main.LogEntry(methodName, $"Preparing to send chat message: {message}");
-        
-            string jsonMessage = $"{{\"broadcaster_id\":\"{user_id}\",\"sender_id\":\"{user_id}\",\"message\":\"{message.Replace("\"", "\\\"")}\"}}";
+
+            string jsonMessage = JsonConvert.SerializeObject(new
+            {
+                broadcaster_id = user_id,
+                sender_id = user_id,
+                message
+            });
             var content = new StringContent(jsonMessage, Encoding.UTF8, "application/json");
-        
-            Main.LogEntry(methodName, $"Created content: {content}");
-        
+
             try
             {
                 var response = await httpClient.PostAsync("https://api.twitch.tv/helix/chat/messages", content);
                 Main.LogEntry(methodName, $"Received response: {response.StatusCode}");
-        
+
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
-                    Main.LogEntry(methodName, "Failed to send chat message.");
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    Main.LogEntry(methodName, $"Failed to send chat message. Error: {errorContent}");
+                    return;
                 }
-                else
+
+                // Twitch answers 200 even when the message was dropped (for example by AutoMod), so check the body.
+                var responseContent = await response.Content.ReadAsStringAsync();
+                JToken? result = JObject.Parse(responseContent).SelectToken("data[0]");
+                bool isSent = result?["is_sent"]?.Value<bool>() ?? true;
+                if (!isSent)
                 {
-                    Main.LogEntry(methodName, $"Sent chat message: {message}");
-                    Main.LogEntry("SentMessage", $"Sent Message: {message}");
+                    string dropReason = (string?)result?.SelectToken("drop_reason.message") ?? "unknown";
+                    Main.LogEntry(methodName, $"Chat message was dropped by Twitch: {dropReason}");
+                    return;
                 }
+
+                Main.LogEntry(methodName, $"Sent chat message: {message}");
+                Main.LogEntry("SentMessage", $"Sent Message: {message}");
             }
             catch (Exception ex)
             {
@@ -198,7 +197,12 @@ namespace TwitchChat
             string methodName = "SendWhisper";
             Main.LogEntry(methodName, $"Preparing to send whisper to user {toUserId}: {message}");
 
-            string jsonMessage = $"{{\"from_user_id\":\"{user_id}\",\"to_user_id\":\"{toUserId}\",\"message\":\"{message.Replace("\"", "\\\"")}\"}}";
+            string jsonMessage = JsonConvert.SerializeObject(new
+            {
+                from_user_id = user_id,
+                to_user_id = toUserId,
+                message
+            });
             var content = new StringContent(jsonMessage, Encoding.UTF8, "application/json");
 
             try
@@ -234,13 +238,19 @@ namespace TwitchChat
 
             // Validate color parameter
             color = color.ToLower();
-            string[] validColors = ["blue", "green", "orange", "purple", "primary"]; // primary is the channel’s accent color
+            string[] validColors = ["blue", "green", "orange", "purple", "primary"]; // primary is the channel's accent color
             if (!Array.Exists(validColors, c => c.Equals(color, StringComparison.OrdinalIgnoreCase)))
             {
                 color = "primary";
             }
 
-            string jsonMessage = $"{{\"broadcaster_id\":\"{user_id}\",\"moderator_id\":\"{user_id}\",\"message\":\"{message.Replace("\"", "\\\"")}\",\"color\":\"{color}\"}}";
+            string jsonMessage = JsonConvert.SerializeObject(new
+            {
+                broadcaster_id = user_id,
+                moderator_id = user_id,
+                message,
+                color
+            });
             var content = new StringContent(jsonMessage, Encoding.UTF8, "application/json");
 
             try

--- a/UnityMainThreadDispatcher.cs
+++ b/UnityMainThreadDispatcher.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 /// <remarks>
 /// Unity's API is not thread-safe and must be accessed from the main thread.
 /// This dispatcher ensures that operations from background threads are properly
-/// queued and executed on the main thread.
+/// queued and executed on the main thread. The singleton is registered in Awake so
+/// <see cref="Instance"/> never has to call into Unity from a background thread.
 /// </remarks>
 public class UnityMainThreadDispatcher : MonoBehaviour
 {
@@ -16,26 +17,34 @@ public class UnityMainThreadDispatcher : MonoBehaviour
     private static readonly Queue<Action> _executionQueue = new();
 
     /// <summary>Singleton instance of the dispatcher</summary>
-    private static UnityMainThreadDispatcher _instance = null!;
+    private static UnityMainThreadDispatcher? _instance;
+
+    private void Awake()
+    {
+        _instance = this;
+    }
 
     /// <summary>
     /// Gets the singleton instance of the UnityMainThreadDispatcher.
-    /// Creates a new GameObject with the dispatcher if one doesn't exist.
+    /// Creates a new GameObject with the dispatcher if one doesn't exist (main thread only).
     /// </summary>
     /// <returns>The singleton instance of UnityMainThreadDispatcher</returns>
     public static UnityMainThreadDispatcher Instance()
     {
-        if (_instance == null)
+        // Reference comparison on purpose: Unity's overloaded == is not safe off the main thread.
+        UnityMainThreadDispatcher? instance = _instance;
+        if (instance is null)
         {
-            _instance = FindObjectOfType<UnityMainThreadDispatcher>();
-            if (_instance == null)
+            instance = FindObjectOfType<UnityMainThreadDispatcher>();
+            if (instance is null)
             {
                 var obj = new GameObject("UnityMainThreadDispatcher");
-                _instance = obj.AddComponent<UnityMainThreadDispatcher>();
+                instance = obj.AddComponent<UnityMainThreadDispatcher>();
                 DontDestroyOnLoad(obj);
             }
+            _instance = instance;
         }
-        return _instance;
+        return instance;
     }
 
     /// <summary>
@@ -52,16 +61,30 @@ public class UnityMainThreadDispatcher : MonoBehaviour
 
     /// <summary>
     /// Unity Update method that processes all queued actions on the main thread.
-    /// Executes all pending actions in the execution queue.
+    /// Each action runs outside the lock and is isolated, so one failure cannot block the rest.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>")]
     private void Update()
     {
-        lock (_executionQueue)
+        while (true)
         {
-            while (_executionQueue.Count > 0)
+            Action action;
+            lock (_executionQueue)
             {
-                _executionQueue.Dequeue().Invoke();
+                if (_executionQueue.Count == 0)
+                {
+                    return;
+                }
+                action = _executionQueue.Dequeue();
+            }
+
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                TwitchChat.Main.LogEntry("UnityMainThreadDispatcher", $"Queued action failed: {ex.Message}");
             }
         }
     }

--- a/WebSocketClient.cs
+++ b/WebSocketClient.cs
@@ -1,11 +1,13 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.WebSockets;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace TwitchChat
 {
@@ -15,40 +17,58 @@ namespace TwitchChat
     /// <remarks>
     /// This class is responsible for:
     /// - Establishing and maintaining WebSocket connections to Twitch's EventSub service
-    /// - Handling connection monitoring and automatic reconnection
+    /// - Reassembling fragmented frames into complete JSON messages
+    /// - Honouring Twitch-initiated session reconnects without dropping subscriptions
+    /// - Handling connection monitoring and automatic reconnection with backoff
     /// - Processing incoming messages and events
-    /// - Managing connection state and health checks
     /// </remarks>
     public class WebSocketManager
     {
-        /// <summary>The WebSocket client instance for Twitch communication</summary>
-        private static ClientWebSocket webSocketClient = new();
-        
-        /// <summary>The current session ID from Twitch</summary>
+        /// <summary>Default EventSub endpoint. Twitch sends a keepalive at least this often when the channel is idle.</summary>
+        private const string EventSubUri = "wss://eventsub.wss.twitch.tv/ws?keepalive_timeout_seconds=30";
+
+        /// <summary>How long a single receive may wait before the connection is considered dead.</summary>
+        private static readonly TimeSpan receiveTimeout = TimeSpan.FromSeconds(45);
+
+        /// <summary>How long without any message before the health monitor declares the connection dead.</summary>
+        private static readonly TimeSpan keepaliveGrace = TimeSpan.FromSeconds(45);
+
+        /// <summary>The active WebSocket client instance for Twitch communication.</summary>
+        private static ClientWebSocket? webSocketClient;
+
+        /// <summary>The previous socket during a Twitch-initiated session migration. Closed once the new session is welcomed.</summary>
+        private static ClientWebSocket? supersededSocket;
+
+        /// <summary>The current session ID from Twitch.</summary>
         private static string session_id = string.Empty;
-        
-        /// <summary>Timestamp of the last received keepalive message</summary>
+
+        /// <summary>Timestamp of the last message received on the active connection.</summary>
         public static DateTime lastKeepaliveTime = DateTime.UtcNow;
-        
-        /// <summary>Indicates whether the connection is currently healthy</summary>
+
+        /// <summary>Indicates whether the connection is currently healthy.</summary>
         private static bool isConnectionHealthy = false;
-        
-        /// <summary>Timer for monitoring connection health</summary>
+
+        /// <summary>Timer for monitoring connection health.</summary>
         private static Timer? connectionMonitorTimer;
-        
-        /// <summary>Public accessor for connection health status</summary>
+
+        /// <summary>Public accessor for connection health status.</summary>
         public static bool IsConnectionHealthy => isConnectionHealthy;
 
         public static string lastMessageType = "None";
         public static string lastChatMessage = "No messages received";
-        // public static string LastMessageType => lastMessageType;
-        // public static string LastChatMessage => lastChatMessage;
         public static DateTime lastTypeReceivedTime = DateTime.UtcNow;
 
         private static readonly SemaphoreSlim reconnectLock = new(1, 1);
         private static int reconnectAttempts = 0;
-        private static readonly int maxReconnectAttempts = 5;
+        private static readonly int maxReconnectAttempts = 8;
         private static readonly TimeSpan reconnectDelay = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan maxReconnectDelay = TimeSpan.FromSeconds(60);
+
+        /// <summary>True from a user-initiated connect until a user-initiated disconnect. Automatic reconnects only happen while this is set.</summary>
+        private static bool userWantsConnection = false;
+
+        /// <summary>Whether the next successful subscription should send the connect chat message. Suppressed for automatic reconnects.</summary>
+        private static bool announceOnWelcome = false;
 
         /// <summary>
         /// Establishes a WebSocket connection to Twitch's EventSub service.
@@ -65,44 +85,111 @@ namespace TwitchChat
                 return;
             }
 
-            if (string .IsNullOrEmpty(Settings.Instance.EncodedOAuthToken))
+            if (string.IsNullOrEmpty(Settings.Instance.EncodedOAuthToken))
             {
                 Main.LogEntry(methodName, "Access token is empty. Cannot attempt connection to WebSocket.");
                 NotificationManager.SetVariable("alertMessage", "Access token is empty. Cannot attempt connection to WebSocket.");
                 return;
             }
 
-            if (webSocketClient.State == WebSocketState.Open)
+            if (webSocketClient?.State == WebSocketState.Open)
             {
                 Main.LogEntry(methodName, "WebSocket is already open. Cannot attempt connection to WebSocket.");
                 NotificationManager.SetVariable("alertMessage", "WebSocket is already open. Cannot attempt connection to WebSocket.");
                 return;
             }
 
+            // The chat subscription needs the broadcaster's numeric ID. Look it up if the token was never validated this session.
+            if (string.IsNullOrEmpty(TwitchEventHandler.user_id))
+            {
+                Main.LogEntry(methodName, "User ID not yet known, looking it up before connecting.");
+                try
+                {
+                    await TwitchEventHandler.GetUserID();
+                }
+                catch (Exception ex)
+                {
+                    Main.LogEntry(methodName, $"User ID lookup failed: {ex.Message}");
+                }
+
+                if (string.IsNullOrEmpty(TwitchEventHandler.user_id))
+                {
+                    NotificationManager.SetVariable("alertMessage", "Could not look up your Twitch user ID. Validate your token and try again.");
+                    return;
+                }
+            }
+
+            userWantsConnection = true;
+            announceOnWelcome = true;
+            reconnectAttempts = 0;
+            await OpenSocketAsync(new Uri(EventSubUri), isSessionMigration: false);
+        }
+
+        /// <summary>
+        /// Opens a new socket to the given URI and starts its receive loop.
+        /// </summary>
+        /// <param name="serverUri">EventSub endpoint to connect to.</param>
+        /// <param name="isSessionMigration">True when following a Twitch session_reconnect request, in which case the old socket is kept open until the new session is welcomed.</param>
+        /// <returns>True if the socket connected.</returns>
+        private static async Task<bool> OpenSocketAsync(Uri serverUri, bool isSessionMigration)
+        {
+            string methodName = "OpenSocketAsync";
+            ClientWebSocket socket = new();
             try
             {
-                Uri serverUri = new("wss://eventsub.wss.twitch.tv/ws?keepalive_timeout_seconds=30");
-                
-                webSocketClient?.Dispose();
-                webSocketClient = new ClientWebSocket();
-                await webSocketClient.ConnectAsync(serverUri, CancellationToken.None);
-                Main.LogEntry(methodName, "Connected to WebSocket server.");
+                using CancellationTokenSource connectCts = new(TimeSpan.FromSeconds(20));
+                await socket.ConnectAsync(serverUri, connectCts.Token);
+                Main.LogEntry(methodName, $"Connected to WebSocket server ({serverUri.Host}){(isSessionMigration ? " for session migration" : "")}.");
 
-                // Initialize connection monitoring
+                if (isSessionMigration)
+                {
+                    supersededSocket = webSocketClient;
+                }
+                else
+                {
+                    ClientWebSocket? stale = webSocketClient;
+                    if (stale != null && stale.State != WebSocketState.Open)
+                    {
+                        stale.Dispose();
+                    }
+                }
+                webSocketClient = socket;
+
                 lastKeepaliveTime = DateTime.UtcNow;
                 isConnectionHealthy = true;
-                connectionMonitorTimer = new Timer(CheckConnectionHealth, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
+                StartConnectionMonitor();
 
-                // Start receiving messages
-                _ = Task.Run(ReceiveMessages);
-                
-
+                _ = Task.Run(() => ReceiveMessages(socket, isSessionMigration));
+                return true;
             }
             catch (Exception ex)
             {
-                isConnectionHealthy = false;
+                socket.Dispose();
+                if (!isSessionMigration)
+                {
+                    isConnectionHealthy = false;
+                }
                 Main.LogEntry(methodName, $"Connection error: {ex.Message}");
+                return false;
             }
+        }
+
+        /// <summary>
+        /// Starts (or restarts) the periodic connection health check.
+        /// </summary>
+        private static void StartConnectionMonitor()
+        {
+            connectionMonitorTimer?.Dispose();
+            connectionMonitorTimer = new Timer(CheckConnectionHealth, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
+        }
+
+        /// <summary>
+        /// Stops the periodic connection health check.
+        /// </summary>
+        private static void StopConnectionMonitor()
+        {
+            connectionMonitorTimer?.Dispose();
+            connectionMonitorTimer = null;
         }
 
         /// <summary>
@@ -111,178 +198,278 @@ namespace TwitchChat
         /// <param name="state">Timer state object (unused).</param>
         private static void CheckConnectionHealth(object state)
         {
-            var timeSinceLastKeepalive = DateTime.UtcNow - lastKeepaliveTime;
+            ClientWebSocket? socket = webSocketClient;
+            TimeSpan timeSinceLastKeepalive = DateTime.UtcNow - lastKeepaliveTime;
             bool wasHealthy = isConnectionHealthy;
-            
-            // Reduce the threshold to 35 seconds (Twitch timeout is 30s)
-            isConnectionHealthy = timeSinceLastKeepalive <= TimeSpan.FromSeconds(35) 
-                && webSocketClient.State == WebSocketState.Open;
+
+            isConnectionHealthy = socket != null
+                && socket.State == WebSocketState.Open
+                && timeSinceLastKeepalive <= keepaliveGrace;
 
             if (wasHealthy && !isConnectionHealthy)
             {
-                Main.LogEntry("CheckConnectionHealth", $"Connection appears to be dead (no keepalive for {timeSinceLastKeepalive.TotalSeconds:F1}s)");
+                Main.LogEntry("CheckConnectionHealth", $"Connection appears to be dead (no message for {timeSinceLastKeepalive.TotalSeconds:F1}s)");
                 _ = ReconnectAsync();
             }
             else if (!wasHealthy && isConnectionHealthy)
             {
                 Main.LogEntry("CheckConnectionHealth", "Connection restored");
-                reconnectAttempts = 0; // Reset reconnect attempts when connection is healthy
+                reconnectAttempts = 0;
             }
         }
 
         /// <summary>
-        /// Attempts to reconnect the WebSocket connection by disconnecting and connecting again.
+        /// Attempts to re-establish a lost connection with exponential backoff.
+        /// Only one reconnect sequence runs at a time, and none run after a user-initiated disconnect.
         /// </summary>
         private static async Task ReconnectAsync()
         {
+            string methodName = "ReconnectAsync";
+
+            if (!await reconnectLock.WaitAsync(0))
+            {
+                Main.LogEntry(methodName, "Reconnection already in progress");
+                return;
+            }
+
             try
             {
-                if (!await reconnectLock.WaitAsync(0)) // Don't wait if already reconnecting
+                while (userWantsConnection && reconnectAttempts < maxReconnectAttempts)
                 {
-                    Main.LogEntry("ReconnectAsync", "Reconnection already in progress");
-                    return;
-                }
+                    reconnectAttempts++;
+                    double backoffSeconds = Math.Min(maxReconnectDelay.TotalSeconds, reconnectDelay.TotalSeconds * Math.Pow(2, reconnectAttempts - 1));
+                    Main.LogEntry(methodName, $"Attempting reconnect {reconnectAttempts}/{maxReconnectAttempts} in {backoffSeconds:F0}s");
 
-                using (reconnectLock)
-                {
-                    if (reconnectAttempts >= maxReconnectAttempts)
+                    await CloseSocketQuietly(webSocketClient, "Reconnecting");
+                    await Task.Delay(TimeSpan.FromSeconds(backoffSeconds));
+
+                    if (!userWantsConnection)
                     {
-                        Main.LogEntry("ReconnectAsync", "Max reconnection attempts reached");
-                        isConnectionHealthy = false;
                         return;
                     }
 
-                    Main.LogEntry("ReconnectAsync", $"Attempting reconnect {reconnectAttempts + 1}/{maxReconnectAttempts}");
-                    
-                    await DisconnectFromoWebSocket();
-                    
-                    // Add delay before reconnecting
-                    await Task.Delay(reconnectDelay);
-                    
-                    await ConnectToWebSocket();
-                    reconnectAttempts++;
+                    announceOnWelcome = false;
+                    if (await OpenSocketAsync(new Uri(EventSubUri), isSessionMigration: false))
+                    {
+                        return;
+                    }
+                }
+
+                if (userWantsConnection)
+                {
+                    Main.LogEntry(methodName, "Max reconnection attempts reached");
+                    isConnectionHealthy = false;
+                    NotificationManager.SetVariable("alertMessage", "Lost connection to Twitch and could not reconnect. Use the Status panel to reconnect.");
                 }
             }
             catch (Exception ex)
             {
-                Main.LogEntry("ReconnectAsync", $"Reconnection error: {ex.Message}");
+                Main.LogEntry(methodName, $"Reconnection error: {ex.Message}");
                 isConnectionHealthy = false;
+            }
+            finally
+            {
+                reconnectLock.Release();
             }
         }
 
         /// <summary>
-        /// Continuously receives and processes messages from the WebSocket connection.
+        /// Sends a close frame on the given socket without any chat announcements.
+        /// The socket's receive loop completes the handshake and disposes it.
         /// </summary>
-        private static async Task ReceiveMessages()
+        private static async Task CloseSocketQuietly(ClientWebSocket? socket, string reason)
+        {
+            if (socket == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
+                {
+                    using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, reason, cts.Token);
+                }
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("CloseSocketQuietly", $"Close failed ({reason}): {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Continuously receives and processes messages from one WebSocket connection.
+        /// Frames are accumulated until EndOfMessage so long payloads are never truncated.
+        /// </summary>
+        /// <param name="socket">The socket to read from.</param>
+        /// <param name="isSessionMigration">True if this socket was opened in response to a session_reconnect request.</param>
+        private static async Task ReceiveMessages(ClientWebSocket socket, bool isSessionMigration)
         {
             string methodName = "ReceiveMessages";
-            var buffer = new byte[1024 * 4];
+            byte[] buffer = new byte[8192];
+            using MemoryStream messageStream = new();
+            bool closeRequestedByServer = false;
 
-            while (webSocketClient.State == WebSocketState.Open)
+            while (socket.State == WebSocketState.Open)
             {
                 try
                 {
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(35));
-                    var result = await webSocketClient.ReceiveAsync(
-                        new ArraySegment<byte>(buffer), 
-                        cts.Token
-                    );
-
-                    // Reset connection monitoring on any successful message
-                    lastKeepaliveTime = DateTime.UtcNow;
-
-                    // Simple string-based message type extraction
-                    string messageType = ExtractValue(Encoding.UTF8.GetString(buffer, 0, result.Count), "message_type");
-                    lastMessageType = messageType;
-
-                    switch (messageType)
+                    messageStream.SetLength(0);
+                    WebSocketReceiveResult result;
+                    do
                     {
-                        case "session_welcome":
-                            session_id = ExtractValue(Encoding.UTF8.GetString(buffer, 0, result.Count), "id");
-                            Main.LogEntry(methodName, $"Session ID: {session_id}");
-                            Main.LogEntry(methodName, "TwitchChat connected to WebSocket");
-                            await RegisterWebbSocketChatEvent();
+                        using CancellationTokenSource cts = new(receiveTimeout);
+                        result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
                             break;
-
-                        case "notification":
-                            string userName = ExtractValue(Encoding.UTF8.GetString(buffer, 0, result.Count), "chatter_user_name");
-                            string chatMessage = ExtractValue(Encoding.UTF8.GetString(buffer, 0, result.Count), "text");
-                            lastChatMessage = $"{userName}: {chatMessage}";
-                            NotificationManager.HandleNotification(Encoding.UTF8.GetString(buffer, 0, result.Count));
-                            break;
-
-                        case "session_keepalive":
-                            lastKeepaliveTime = DateTime.UtcNow;
-                            isConnectionHealthy = true;
-                            Main.LogEntry(methodName, "Received keepalive message.");
-                            break;
-
-                        case "session_reconnect":
-                            Main.LogEntry(methodName, "Received reconnect message.");
-                            break;
-
-                        case "revocation":
-                            Main.LogEntry(methodName, "Received revocation message.");
-                            break;
-
-                        default:
-                            Main.LogEntry(methodName, $"Unknown message type: {messageType}");
-                            break;
+                        }
+                        messageStream.Write(buffer, 0, result.Count);
                     }
+                    while (!result.EndOfMessage);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        closeRequestedByServer = true;
+                        Main.LogEntry(methodName, $"Server closed the connection: {(socket.CloseStatus.HasValue ? (int)socket.CloseStatus.Value : 0)} {socket.CloseStatusDescription}");
+                        break;
+                    }
+
+                    if (socket == webSocketClient)
+                    {
+                        lastKeepaliveTime = DateTime.UtcNow;
+                    }
+
+                    string json = Encoding.UTF8.GetString(messageStream.GetBuffer(), 0, (int)messageStream.Length);
+                    await HandleMessage(json, socket, isSessionMigration);
                 }
                 catch (OperationCanceledException)
                 {
-                    Main.LogEntry(methodName, "Receive operation timed out");
-                    isConnectionHealthy = false;
-                    _ = ReconnectAsync();
+                    if (socket == webSocketClient)
+                    {
+                        Main.LogEntry(methodName, "Receive operation timed out");
+                    }
                     break;
                 }
                 catch (WebSocketException wsEx)
                 {
                     Main.LogEntry(methodName, $"WebSocket error: {wsEx.Message}");
-                    isConnectionHealthy = false;
-                    _ = ReconnectAsync();
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
                     break;
                 }
                 catch (Exception ex)
                 {
-                    Main.LogEntry(methodName, $"Error receiving message: {ex.Message}");
-                    continue;
+                    // A bad or unexpected message should not take the connection down.
+                    Main.LogEntry(methodName, $"Error handling message: {ex.Message}");
                 }
             }
-            
-            if (webSocketClient.CloseStatus.HasValue)
+
+            if (closeRequestedByServer)
             {
-                string closeReason = webSocketClient.CloseStatusDescription;
-                int closeCode = (int)webSocketClient.CloseStatus.Value;
-                Main.LogEntry(methodName, $"WebSocket connection closed with code {closeCode}: {closeReason}");
+                await CloseSocketQuietly(socket, "Acknowledging close");
             }
-            else
+
+            bool wasCurrent = socket == webSocketClient;
+            string closeInfo = socket.CloseStatus.HasValue
+                ? $"code {(int)socket.CloseStatus.Value}: {socket.CloseStatusDescription}"
+                : "no close status";
+            Main.LogEntry(methodName, $"WebSocket connection closed ({closeInfo}){(wasCurrent ? "" : " [superseded connection]")}.");
+
+            if (socket == supersededSocket)
             {
-                Main.LogEntry(methodName, "WebSocket connection closed.");
+                supersededSocket = null;
+            }
+            socket.Dispose();
+
+            if (wasCurrent)
+            {
+                isConnectionHealthy = false;
+                if (userWantsConnection)
+                {
+                    Main.LogEntry(methodName, "Connection lost, scheduling reconnect.");
+                    _ = ReconnectAsync();
+                }
             }
         }
 
-        private static string ExtractValue(string json, string key)
+        /// <summary>
+        /// Dispatches one complete EventSub message.
+        /// </summary>
+        private static async Task HandleMessage(string json, ClientWebSocket socket, bool isSessionMigration)
         {
-            int keyIndex = json.IndexOf($"\"{key}\"");
-            if (keyIndex == -1) return string.Empty;
+            string methodName = "HandleMessage";
+            JObject message = JObject.Parse(json);
+            string messageType = (string?)message.SelectToken("metadata.message_type") ?? "unknown";
+            lastMessageType = messageType;
+            lastTypeReceivedTime = DateTime.UtcNow;
 
-            int valueStart = json.IndexOf(':', keyIndex) + 1;
-            while (valueStart < json.Length && char.IsWhiteSpace(json[valueStart])) valueStart++;
-
-            if (valueStart >= json.Length) return string.Empty;
-
-            if (json[valueStart] == '"')
+            switch (messageType)
             {
-                valueStart++;
-                int valueEnd = json.IndexOf('"', valueStart);
-                return valueEnd == -1 ? string.Empty : json.Substring(valueStart, valueEnd - valueStart);
-            }
-            else
-            {
-                int valueEnd = json.IndexOfAny([',', '}'], valueStart);
-                return valueEnd == -1 ? string.Empty : json.Substring(valueStart, valueEnd - valueStart).Trim();
+                case "session_welcome":
+                    session_id = (string?)message.SelectToken("payload.session.id") ?? string.Empty;
+                    Main.LogEntry(methodName, $"Session ID: {session_id}");
+                    reconnectAttempts = 0;
+                    if (isSessionMigration)
+                    {
+                        // Twitch carries existing subscriptions over to the new session; only the old socket needs closing.
+                        Main.LogEntry(methodName, "Session migrated to new connection, closing the old one.");
+                        ClientWebSocket? old = supersededSocket;
+                        supersededSocket = null;
+                        await CloseSocketQuietly(old, "Session migrated");
+                    }
+                    else
+                    {
+                        Main.LogEntry(methodName, "TwitchChat connected to WebSocket");
+                        await RegisterWebbSocketChatEvent();
+                    }
+                    break;
+
+                case "notification":
+                    string userName = (string?)message.SelectToken("payload.event.chatter_user_name") ?? string.Empty;
+                    string chatMessage = (string?)message.SelectToken("payload.event.message.text") ?? string.Empty;
+                    lastChatMessage = $"{userName}: {chatMessage}";
+                    NotificationManager.HandleNotification(message);
+                    break;
+
+                case "session_keepalive":
+                    if (socket == webSocketClient)
+                    {
+                        lastKeepaliveTime = DateTime.UtcNow;
+                        isConnectionHealthy = true;
+                    }
+                    Main.LogEntry(methodName, "Received keepalive message.");
+                    break;
+
+                case "session_reconnect":
+                    string reconnectUrl = (string?)message.SelectToken("payload.session.reconnect_url") ?? string.Empty;
+                    if (socket != webSocketClient)
+                    {
+                        Main.LogEntry(methodName, "Ignoring reconnect request on a superseded connection.");
+                    }
+                    else if (string.IsNullOrEmpty(reconnectUrl))
+                    {
+                        Main.LogEntry(methodName, "Reconnect request had no URL; the health monitor will handle it.");
+                    }
+                    else
+                    {
+                        Main.LogEntry(methodName, "Twitch requested a session reconnect, migrating.");
+                        _ = OpenSocketAsync(new Uri(reconnectUrl), isSessionMigration: true);
+                    }
+                    break;
+
+                case "revocation":
+                    string status = (string?)message.SelectToken("payload.subscription.status") ?? "unknown";
+                    Main.LogEntry(methodName, $"Chat subscription revoked: {status}");
+                    NotificationManager.SetVariable("alertMessage", $"Twitch revoked the chat subscription ({status}). Re-authorize the mod and reconnect.");
+                    break;
+
+                default:
+                    Main.LogEntry(methodName, $"Unknown message type: {messageType}");
+                    break;
             }
         }
 
@@ -292,75 +479,84 @@ namespace TwitchChat
         private static async Task RegisterWebbSocketChatEvent()
         {
             string methodName = "RegisterWebbSocketChatEvent";
-            if (webSocketClient.State != WebSocketState.Open)
+            if (webSocketClient?.State != WebSocketState.Open)
             {
                 Main.LogEntry(methodName, "WebSocket is not open. Cannot send subscription request.");
                 return;
             }
 
-            var jsonBody = $@"{{
-                ""type"": ""channel.chat.message"",
-                ""version"": ""1"",
-                ""condition"": {{
-                    ""broadcaster_user_id"": ""{TwitchEventHandler.user_id}"",
-                    ""user_id"": ""{TwitchEventHandler.user_id}""
-                }},
-                ""transport"": {{
-                    ""method"": ""websocket"",
-                    ""session_id"": ""{session_id}""
-                }}
-            }}";
-            var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-        
+            string jsonBody = JsonConvert.SerializeObject(new
+            {
+                type = "channel.chat.message",
+                version = "1",
+                condition = new
+                {
+                    broadcaster_user_id = TwitchEventHandler.user_id,
+                    user_id = TwitchEventHandler.user_id
+                },
+                transport = new
+                {
+                    method = "websocket",
+                    session_id
+                }
+            });
+            StringContent content = new(jsonBody, Encoding.UTF8, "application/json");
+
             byte[] tokenBytes = Convert.FromBase64String(Settings.Instance.EncodedOAuthToken);
-            _ = Encoding.UTF8.GetString(tokenBytes);
             string access_token = Encoding.UTF8.GetString(tokenBytes);
 
             TwitchEventHandler.httpClient.DefaultRequestHeaders.Clear();
             TwitchEventHandler.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", access_token);
             TwitchEventHandler.httpClient.DefaultRequestHeaders.Add("Client-ID", TwitchEventHandler.GetClientId());
-            var response = await TwitchEventHandler.httpClient.PostAsync("https://api.twitch.tv/helix/eventsub/subscriptions", content);
+            HttpResponseMessage response = await TwitchEventHandler.httpClient.PostAsync("https://api.twitch.tv/helix/eventsub/subscriptions", content);
             if (response.StatusCode != System.Net.HttpStatusCode.Accepted)
             {
-                var errorContent = await response.Content.ReadAsStringAsync();
+                string errorContent = await response.Content.ReadAsStringAsync();
                 Main.LogEntry(methodName, $"Failed to subscribe to channel.chat.message. Status: {response.StatusCode}, Error: {errorContent}");
+                NotificationManager.SetVariable("alertMessage", $"Twitch chat subscription failed ({(int)response.StatusCode}). Check the debug log.");
+                return;
             }
-            else
+
+            Main.LogEntry(methodName, "Subscribed to channel.chat.message.");
+            if (announceOnWelcome && Settings.Instance.connectMessageEnabled && !string.IsNullOrEmpty(Settings.Instance.connectMessage))
             {
-                Main.LogEntry(methodName, "Subscribed to channel.chat.message.");
-                if (!string.IsNullOrEmpty(Settings.Instance.connectMessage) && Settings.Instance.connectMessageEnabled)
-                {
-                    await TwitchEventHandler.SendMessage(Settings.Instance.connectMessage);
-                }
+                await TwitchEventHandler.SendMessage(Settings.Instance.connectMessage);
             }
+            announceOnWelcome = false;
         }
 
         /// <summary>
-        /// Gracefully disconnects from the WebSocket server.
+        /// Gracefully disconnects from the WebSocket server at the user's request.
+        /// No automatic reconnect follows.
         /// </summary>
-        public static async Task DisconnectFromoWebSocket()
+        public static async Task DisconnectFromWebSocket()
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
-            
-            if (webSocketClient.State == WebSocketState.Open)
+            string methodName = "DisconnectFromWebSocket";
+
+            userWantsConnection = false;
+            announceOnWelcome = false;
+            StopConnectionMonitor();
+
+            ClientWebSocket? socket = webSocketClient;
+            if (socket != null && socket.State == WebSocketState.Open)
             {
-                if (!string.IsNullOrEmpty(Settings.Instance.disconnectMessage))
+                if (Settings.Instance.disconnectMessageEnabled && !string.IsNullOrEmpty(Settings.Instance.disconnectMessage))
                 {
-                    if (Settings.Instance.disconnectMessageEnabled)
-                    {
-                        await TwitchEventHandler.SendMessage(Settings.Instance.disconnectMessage);
-                    }
-                    
+                    await TwitchEventHandler.SendMessage(Settings.Instance.disconnectMessage);
                     // Small delay to ensure the message is sent before closing
                     await Task.Delay(500);
                 }
-                
-                connectionMonitorTimer?.Dispose();
-                isConnectionHealthy = false;
-                await webSocketClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+
+                await CloseSocketQuietly(socket, "Closing");
                 Main.LogEntry(methodName, "Disconnected from WebSocket server.");
                 AutomatedMessages.StopAndClearTimers();
             }
+            else
+            {
+                Main.LogEntry(methodName, "WebSocket was not open.");
+            }
+
+            isConnectionHealthy = false;
         }
     }
 }


### PR DESCRIPTION
## Summary

Derail Valley Build 99 broke TwitchChat 3.1.0 in two places. The game's notification API gained two optional parameters, so the compiled DLL referenced a method that no longer exists, `OnToggle` threw `MissingMethodException`, and Unity Mod Manager never activated the mod. Separately, the license-paper panel system relied on exact object names and hierarchy paths that no longer hold. This PR fixes the compatibility break, hardens the Twitch connection, and replaces the license hack with two new panel hosts.

## What changed

### 3.2.0: compatibility and connection robustness

- Rebuilt against the current game assemblies. The notification call now lives in a non-inlined method with a reflection fallback, so a future signature change degrades gracefully instead of killing the toggle.
- `OnToggle` uses its enabled argument and cannot fail on a notification error. Log files are initialised before the first log call.
- WebSocket frames are reassembled until `EndOfMessage`, so long chat messages are no longer truncated. Parsing switched from string searching to the game-shipped Newtonsoft.Json; outgoing bodies are serialised properly and Twitch-dropped messages are logged.
- Twitch `session_reconnect` is honoured (subscriptions carry over), lost connections retry with exponential backoff, the reconnect lock is no longer disposed after first use, and connect/disconnect chat announcements only fire for manual actions.
- All Unity work from the receive thread is marshalled to the main thread; the dispatcher registers itself in `Awake`.
- Timed-message status updates again, panel-driven settings saves are debounced, and received messages are written to the Messages log.

### 3.3.0: cab display and wrist panel

- New `PanelHost` base with `LicenseHost`, `CabDisplayHost` and `WristPanelHost` (`PanelHost.cs`, `MenuManager.cs`).
- Licenses are found through `StorageController.GetAllStorageItems()` by prefab name, the printed page is hidden via the `Page` component, and sticky tape is read from `SnappableItem.IsSnapped`. Legacy license mode is optional and logs what the game reports.
- Cab display: parented to the locomotive interior, placed at the gaze point (F7 or the Place Display button), pose saved per car livery and restored on boarding, F8 or Toggle Display hides it.
- Wrist panel (VR only): parented to a VRTK controller, with hand, scale, offset and rotation tunable live from the Unity Mod Manager menu.
- Unity Mod Manager settings gain a section for hotkeys, placement distance and wrist tuning. The Main panel gains Place Display and Toggle Display buttons and is 30 px taller.

## Reviewer notes

- Build with the .NET 8 SDK: `dotnet build -c Release`. The post-build step copies into the game folder and runs `package.ps1`; the zip lands in `dist/`.
- In-game status: 3.2.0 was confirmed to load and activate on Build 99 in both flat and VR mode. 3.3.0 compiles and is deployed but has not yet been exercised in-game. The wrist panel default pose is a first guess and is expected to need tuning with the sliders.
- New game assembly references: `Newtonsoft.Json`, `VRTK`, `WorldStreamer`, `DV.ThingTypes`. The `UnityEngine.EventSystems` reference, which does not exist in the game, was removed.
- `Settings.xml` gains new fields; existing files load with defaults.
- The edited files were normalised to LF in the working tree; git's autocrlf setting handles checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
