### PR TITLE
Drop the license paper menus, add VR grab bars for the cab display, and fix panel colliders disturbing locomotive physics

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -303,8 +303,6 @@ namespace TwitchChat
             "ValidateAuthToken",
             "TokenStore",
             "UnityMainThreadDispatcher",
-            "LicenseScan",
-            "HandleLicenseAttachment",
             "CabDisplay",
             "WristPanel"
         ];

--- a/MenuManager.cs
+++ b/MenuManager.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using DV.CabControls;
-using DV.Items;
-using DV.Utils;
 using TwitchChat.PanelDisplays;
 using TwitchChat.PanelMenus;
 using UnityEngine;
@@ -16,30 +13,23 @@ namespace TwitchChat
     /// Manages the creation, positioning, and interaction of UI menus and panels for the Twitch Chat mod.
     /// </summary>
     /// <remarks>
-    /// Three kinds of host carry the panel stack:
+    /// Two kinds of host carry the panel stack:
     /// - Cab display: one canvas parented to the current locomotive interior, placed where the player is looking.
     ///   Its pose is remembered per locomotive type and restored when the player enters that type again.
     /// - Wrist panel: one canvas parented to a VR controller so it can be glanced at like a watch.
-    /// - License papers (legacy, optional): canvases riding on the six license items. Items are found through the
-    ///   game's storage system by prefab name, so the object name and hierarchy no longer matter.
     /// </remarks>
     public class MenuManager : MonoBehaviour
     {
-        private const float LicenseScanInterval = 1f;
         private const float WristSearchInterval = 2f;
         private const float BaseCanvasScale = 0.001f;
-        private const string PaperFallbackPath = "Pivot/TempPaper(Clone)(Clone) 0/Paper";
 
         private static MenuManager? instance;
-        private readonly Dictionary<string, LicenseHost> licenses = new();
         private readonly CabDisplayHost cabDisplay = new();
         private readonly WristPanelHost wristPanel = new();
-        private readonly HashSet<string> paperLookupFailed = new();
         private GameObject? templateCanvas;
 
-        private float nextLicenseScanTime;
-        private bool licenseInventoryLogged;
         private TrainCar? cabDisplayCar;
+        private PanelGrabHandles? cabDisplayHandles;
         private Transform? wristAnchor;
         private float nextWristSearchTime;
 
@@ -53,10 +43,6 @@ namespace TwitchChat
         {
             get
             {
-                foreach (LicenseHost license in licenses.Values)
-                {
-                    yield return license;
-                }
                 yield return cabDisplay;
                 yield return wristPanel;
             }
@@ -135,27 +121,6 @@ namespace TwitchChat
                     DontDestroyOnLoad(go);
                 }
                 return instance;
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of MenuManager with the legacy license hosts.
-        /// </summary>
-        public MenuManager()
-        {
-            string[] licenseNames =
-            [
-                "LicenseTrainDriver",
-                "LicenseShunting",
-                "LicenseLocomotiveDE2",
-                "LicenseMuseumCitySouth",
-                "LicenseFreightHaul",
-                "LicenseDispatcher1"
-            ];
-
-            for (int i = 0; i < licenseNames.Length; i++)
-            {
-                licenses.Add(licenseNames[i], new LicenseHost(licenseNames[i], i));
             }
         }
 
@@ -253,29 +218,12 @@ namespace TwitchChat
 
             bool inSession = PlayerManager.PlayerTransform != null;
 
-            if (inSession && Settings.Instance.licensePanelsEnabled)
-            {
-                UpdateLicenseHosts();
-            }
-            else
-            {
-                ReleaseLicenseHosts();
-            }
-
             UpdateCabDisplay(inSession);
             UpdateWristPanel(inSession);
         }
 
         private void LateUpdate()
         {
-            foreach (LicenseHost license in licenses.Values)
-            {
-                if (license.LicenseObject != null && license.MenuCanvas != null && license.MenuCanvas.activeSelf)
-                {
-                    PositionNearObject(license);
-                }
-            }
-
             if (wristAnchor != null && wristPanel.MenuCanvas != null && wristPanel.MenuCanvas.activeSelf)
             {
                 ApplyWristPose();
@@ -309,264 +257,6 @@ namespace TwitchChat
             }
             cachedName = name;
             return Enum.TryParse(name, true, out KeyCode key) ? key : KeyCode.None;
-        }
-
-        // ------------------------------------------------------------------
-        // Legacy license hosts
-        // ------------------------------------------------------------------
-
-        private void UpdateLicenseHosts()
-        {
-            if (Time.unscaledTime >= nextLicenseScanTime)
-            {
-                nextLicenseScanTime = Time.unscaledTime + LicenseScanInterval;
-                ScanForLicenseItems();
-            }
-
-            foreach (LicenseHost license in licenses.Values)
-            {
-                bool visible = license.LicenseObject != null && license.LicenseObject.activeInHierarchy;
-
-                if (license.MenuCanvas != null && license.MenuCanvas.activeSelf != visible)
-                {
-                    license.MenuCanvas.SetActive(visible);
-                    if (visible)
-                    {
-                        ShowPanel(license.ActivePanel, license);
-                    }
-                }
-
-                if (visible)
-                {
-                    UpdatePanelValues(license);
-                    HandleLicenseAttachment(license);
-                    HandlePaperVisibility(license);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Looks the six license items up through the game's storage system, which tracks every item
-        /// regardless of its GameObject name or where it is parented.
-        /// </summary>
-        private void ScanForLicenseItems()
-        {
-            string methodName = "LicenseScan";
-
-            StorageController storage = SingletonBehaviour<StorageController>.Instance;
-            if (storage == null)
-            {
-                return;
-            }
-
-            List<ItemBase> items;
-            try
-            {
-                items = storage.GetAllStorageItems();
-            }
-            catch (Exception ex)
-            {
-                Main.LogEntry(methodName, $"Could not list storage items: {ex.Message}");
-                return;
-            }
-
-            if (!licenseInventoryLogged)
-            {
-                licenseInventoryLogged = true;
-                List<string> licenseNames = items
-                    .Where(i => i != null && i.InventorySpecs != null)
-                    .Select(i => i.InventorySpecs.ItemPrefabName)
-                    .Where(n => !string.IsNullOrEmpty(n) && n.IndexOf("License", StringComparison.OrdinalIgnoreCase) >= 0)
-                    .Distinct()
-                    .ToList();
-                Main.LogEntry(methodName, $"Storage reports {items.Count} items. License items present: {(licenseNames.Count > 0 ? string.Join(", ", licenseNames) : "none")}");
-            }
-
-            foreach (LicenseHost license in licenses.Values)
-            {
-                if (license.Item != null && license.LicenseObject != null)
-                {
-                    continue; // still bound to a live item
-                }
-
-                ItemBase? match = items.FirstOrDefault(i => i != null && i.InventorySpecs != null && i.InventorySpecs.ItemPrefabName == license.PrefabName);
-                if (match == null)
-                {
-                    if (license.Item != null || license.LicenseObject != null)
-                    {
-                        Main.LogEntry(methodName, $"License item {license.PrefabName} is gone; releasing its menu.");
-                        UnbindLicense(license);
-                    }
-                    continue;
-                }
-
-                BindLicense(license, match);
-            }
-        }
-
-        private void BindLicense(LicenseHost license, ItemBase item)
-        {
-            UnbindLicense(license);
-            license.Item = item;
-            license.LicenseObject = item.gameObject;
-            paperLookupFailed.Remove(license.PrefabName);
-
-            Main.LogEntry("LicenseScan", $"Found license item {license.PrefabName} (object '{item.gameObject.name}', active: {item.gameObject.activeInHierarchy}, parent: '{(item.transform.parent != null ? item.transform.parent.name : "none")}')");
-
-            if (license.MenuCanvas == null)
-            {
-                CreateMenuCanvas(license);
-            }
-        }
-
-        private static void UnbindLicense(LicenseHost license)
-        {
-            license.Item = null;
-            license.LicenseObject = null;
-            license.PaperRenderer = null;
-            license.PaperObject = null;
-            license.AttachedToStickyTape = false;
-            license.StickyTapeBase = null;
-        }
-
-        /// <summary>
-        /// Hides license canvases and restores anything the mod hid, used when the legacy mode is off or no session is running.
-        /// </summary>
-        private void ReleaseLicenseHosts()
-        {
-            foreach (LicenseHost license in licenses.Values)
-            {
-                if (license.MenuCanvas != null && license.MenuCanvas.activeSelf)
-                {
-                    license.MenuCanvas.SetActive(false);
-                }
-                if (license.PaperRenderer != null && !license.PaperRenderer.enabled)
-                {
-                    license.PaperRenderer.enabled = true;
-                }
-                if (license.PaperObject != null && !license.PaperObject.activeSelf)
-                {
-                    license.PaperObject.SetActive(true);
-                }
-                if (license.StickyTapeBase != null && !license.StickyTapeBase.activeSelf)
-                {
-                    license.StickyTapeBase.SetActive(true);
-                }
-                license.StickyTapeBase = null;
-                license.AttachedToStickyTape = false;
-            }
-        }
-
-        /// <summary>
-        /// Tracks whether the license is snapped to a sticky tape gadget and hides the tape's backing while it is.
-        /// </summary>
-        private void HandleLicenseAttachment(LicenseHost license)
-        {
-            try
-            {
-                SnappableItem? snappable = license.Item != null ? license.Item.SnappableItem : null;
-                bool snapped = snappable != null && snappable.IsSnapped && snappable.SnappedTo != null;
-                if (snapped == license.AttachedToStickyTape)
-                {
-                    return;
-                }
-
-                license.AttachedToStickyTape = snapped;
-                Main.LogEntry("HandleLicenseAttachment", $"License {license.PrefabName} snapped to a mount: {snapped}");
-
-                if (snapped)
-                {
-                    GameObject? stickerBase = FindStickerBase(snappable!.SnappedTo!.transform);
-                    if (stickerBase != null)
-                    {
-                        license.StickyTapeBase = stickerBase;
-                        stickerBase.SetActive(false);
-                    }
-                }
-                else if (license.StickyTapeBase != null)
-                {
-                    license.StickyTapeBase.SetActive(true);
-                    license.StickyTapeBase = null;
-                }
-            }
-            catch (Exception e)
-            {
-                Main.LogEntry("HandleLicenseAttachment", $"Error: {e.Message}");
-            }
-        }
-
-        private static GameObject? FindStickerBase(Transform snapPoint)
-        {
-            Transform root = snapPoint;
-            for (int i = 0; i < 4 && root.parent != null && root.name.IndexOf("StickyTape", StringComparison.OrdinalIgnoreCase) < 0; i++)
-            {
-                root = root.parent;
-            }
-
-            foreach (Transform child in root.GetComponentsInChildren<Transform>(true))
-            {
-                if (child.name.IndexOf("gadget_sticker_base", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    return child.gameObject;
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Keeps the printed license page hidden while the canvas covers it. Prefers the game's Page component
-        /// and falls back to the fixed child path used by older builds.
-        /// </summary>
-        private void HandlePaperVisibility(LicenseHost license)
-        {
-            if (license.LicenseObject == null)
-            {
-                return;
-            }
-
-            if (license.PaperRenderer == null && license.PaperObject == null && !paperLookupFailed.Contains(license.PrefabName))
-            {
-                Page page = license.LicenseObject.GetComponentInChildren<Page>(true);
-                if (page != null && page.renderer != null)
-                {
-                    license.PaperRenderer = page.renderer;
-                }
-                else
-                {
-                    Transform fallback = license.LicenseObject.transform.Find(PaperFallbackPath);
-                    if (fallback != null)
-                    {
-                        license.PaperObject = fallback.gameObject;
-                    }
-                    else
-                    {
-                        paperLookupFailed.Add(license.PrefabName);
-                        Main.LogEntry("LicenseScan", $"Could not find the printed page of {license.PrefabName}; the canvas will overlay it instead.");
-                    }
-                }
-            }
-
-            if (license.PaperRenderer != null && license.PaperRenderer.enabled)
-            {
-                license.PaperRenderer.enabled = false;
-            }
-            if (license.PaperObject != null && license.PaperObject.activeSelf)
-            {
-                license.PaperObject.SetActive(false);
-            }
-        }
-
-        private void PositionNearObject(LicenseHost license)
-        {
-            if (license.MenuCanvas == null || license.LicenseObject == null)
-            {
-                return;
-            }
-
-            license.MenuCanvas.transform.position = license.LicenseObject.transform.position;
-            license.MenuCanvas.transform.rotation = license.LicenseObject.transform.rotation *
-                                                    Quaternion.Euler(90f, 180f, 0f) *
-                                                    Quaternion.Euler(panelConfigs[PanelType.Main].PanelRotationOffset);
         }
 
         // ------------------------------------------------------------------
@@ -614,6 +304,10 @@ namespace TwitchChat
             if (car == null || cabDisplay.MenuCanvas == null || cabDisplayCar == car)
             {
                 return;
+            }
+            if (cabDisplayHandles != null && cabDisplayHandles.IsHeld)
+            {
+                return; // the player is carrying it between cars; where they let go decides where it lands
             }
             TryRestoreCabDisplay(car);
         }
@@ -718,6 +412,43 @@ namespace TwitchChat
             {
                 NotificationManager.SetVariable("alertMessage", "The cab display has not been placed in this locomotive yet. Use Place Display first.");
             }
+        }
+
+        /// <summary>
+        /// Called by <see cref="PanelGrabHandles"/> when a hand lets go of the display. Re-parents it to whichever
+        /// car the player is in, so it rides along from wherever it was left, and saves the new pose for that
+        /// locomotive type.
+        /// </summary>
+        private void OnCabDisplayReleased()
+        {
+            if (cabDisplay.MenuCanvas == null)
+            {
+                return;
+            }
+
+            Transform canvas = cabDisplay.MenuCanvas.transform;
+            TrainCar? car = PlayerManager.Car;
+            Transform? parent = car != null
+                ? (car.interior != null ? car.interior : car.transform)
+                : WorldMover.OriginShiftParent;
+
+            if (parent != null && canvas.parent != parent)
+            {
+                canvas.SetParent(parent, true);
+            }
+
+            cabDisplayCar = car;
+            cabDisplay.Placed = true;
+
+            string location = "the world";
+            if (car != null)
+            {
+                location = CarKey(car);
+                SavePose(location, canvas.localPosition, canvas.localRotation.eulerAngles);
+            }
+            Settings.Instance.RequestSave();
+
+            Main.LogEntry("CabDisplay", $"Cab display released on {location}.");
         }
 
         private static string CarKey(TrainCar car)
@@ -885,6 +616,13 @@ namespace TwitchChat
             host.Config1Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
             host.Config2Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
             host.DebugPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+
+            // The cab display is the only host the player moves around, so it is the only one that gets grab bars
+            if (host is CabDisplayHost && menuPanel != null)
+            {
+                cabDisplayHandles = host.MenuCanvas.AddComponent<PanelGrabHandles>();
+                cabDisplayHandles.Initialize(menuPanel, OnCabDisplayReleased);
+            }
 
             Main.LogEntry("CreateMenuCanvas", $"Created panel stack for host {host.Name}.");
         }

--- a/PanelConstructor/Button.cs
+++ b/PanelConstructor/Button.cs
@@ -44,6 +44,8 @@ namespace TwitchChat.PanelConstructor
             {
                 BoxCollider boxCollider = buttonObj.AddComponent<BoxCollider>();
                 boxCollider.size = new Vector3(textWidth + 10, 20, 1);
+                // A trigger, so the collider stays out of the physics of whatever the panel is parented to
+                boxCollider.isTrigger = true;
                 
                 WorldUiButtonVr vrButton = buttonObj.AddComponent<WorldUiButtonVr>();
                 vrButton.SetAction(() => clicked?.Invoke());

--- a/PanelConstructor/Slider.cs
+++ b/PanelConstructor/Slider.cs
@@ -181,6 +181,8 @@ namespace TwitchChat.PanelConstructor
             {
                 BoxCollider boxCollider = sliderObj.AddComponent<BoxCollider>();
                 boxCollider.size = new Vector3(width, 20, 1);
+                // A trigger, so the collider stays out of the physics of whatever the panel is parented to
+                boxCollider.isTrigger = true;
                 
                 WorldUiButtonVr vrButton = sliderObj.AddComponent<WorldUiButtonVr>();
                 vrButton.SetAction(() => {

--- a/PanelConstructor/Toggle.cs
+++ b/PanelConstructor/Toggle.cs
@@ -55,6 +55,8 @@ namespace TwitchChat.PanelConstructor
             {
                 BoxCollider boxCollider = toggleObj.AddComponent<BoxCollider>();
                 boxCollider.size = new Vector3(textWidth + 10, 20, 1);
+                // A trigger, so the collider stays out of the physics of whatever the panel is parented to
+                boxCollider.isTrigger = true;
                 
                 WorldUiButtonVr vrButton = toggleObj.AddComponent<WorldUiButtonVr>();
                 vrButton.SetAction(() => {

--- a/PanelGrabHandles.cs
+++ b/PanelGrabHandles.cs
@@ -1,0 +1,328 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using VRTK;
+
+namespace TwitchChat
+{
+    /// <summary>
+    /// Grab bars around the four edges of the cab display. Bringing a hand to a bar highlights it, and
+    /// squeezing the grip then carries the display with that hand until the grip is released, the way the
+    /// license papers used to be picked up. Position and rotation both follow the hand, and the new pose is
+    /// saved for the locomotive on release.
+    /// </summary>
+    /// <remarks>
+    /// The component lives on the cab display canvas, so it dies with the canvas and stops running whenever
+    /// the display is hidden. It only ever reads controller state; nothing here depends on the game's item
+    /// or grab systems, which is what made the old license menus break between game builds.
+    /// </remarks>
+    public class PanelGrabHandles : MonoBehaviour
+    {
+        /// <summary>Bar width in canvas units. The canvas is scaled to millimetres, so this is 14 mm at scale 1.</summary>
+        private const float BarThickness = 14f;
+
+        /// <summary>How far in front of and behind the panel a bar can be reached, in canvas units.</summary>
+        private const float BarDepth = 40f;
+
+        /// <summary>How close a hand has to get to a bar before the grip picks the display up, in metres.</summary>
+        private const float ReachDistance = 0.08f;
+
+        private const float ControllerSearchInterval = 2f;
+        private const int BarCount = 4;
+
+        private static readonly Color IdleColor = new(1f, 1f, 1f, 0.2f);
+        private static readonly Color ReadyColor = new(0.35f, 0.75f, 1f, 0.6f);
+        private static readonly Color HeldColor = new(0.4f, 1f, 0.5f, 0.8f);
+
+        private readonly RectTransform[] barRects = new RectTransform[BarCount];
+        private readonly Image[] barImages = new Image[BarCount];
+
+        private RectTransform? panelRect;
+        private Action? released;
+
+        private Transform? leftHand;
+        private Transform? rightHand;
+        private VRTK_ControllerEvents? leftEvents;
+        private VRTK_ControllerEvents? rightEvents;
+        private float nextControllerSearch;
+
+        private Transform? holdingHand;
+        private VRTK_ControllerEvents? holdingEvents;
+        private Vector3 holdOffsetPosition;
+        private Quaternion holdOffsetRotation;
+
+        private int highlightedBar = -1;
+        private bool barsVisible = true;
+
+        /// <summary>True while a hand is carrying the display.</summary>
+        public bool IsHeld => holdingHand != null;
+
+        /// <summary>
+        /// Builds the bars around the given panel rect.
+        /// </summary>
+        /// <param name="menuPanel">The MenuPanel transform the bars frame.</param>
+        /// <param name="onReleased">Called each time the display is let go, so the new pose can be saved.</param>
+        public void Initialize(Transform menuPanel, Action onReleased)
+        {
+            panelRect = menuPanel.GetComponent<RectTransform>();
+            released = onReleased;
+
+            if (panelRect == null)
+            {
+                Main.LogEntry("CabDisplay", "Grab handles: the menu panel has no RectTransform, so no bars were created.");
+                return;
+            }
+
+            CreateBars(panelRect);
+        }
+
+        private void CreateBars(RectTransform parent)
+        {
+            // Each bar sits just outside one edge of the panel and stretches along with it
+            barRects[0] = CreateBar(parent, "GrabHandle_Top", new Vector2(0f, 1f), Vector2.one, new Vector2(0.5f, 0f), new Vector2(BarThickness * 2f, BarThickness));
+            barRects[1] = CreateBar(parent, "GrabHandle_Bottom", Vector2.zero, new Vector2(1f, 0f), new Vector2(0.5f, 1f), new Vector2(BarThickness * 2f, BarThickness));
+            barRects[2] = CreateBar(parent, "GrabHandle_Left", Vector2.zero, new Vector2(0f, 1f), new Vector2(1f, 0.5f), new Vector2(BarThickness, 0f));
+            barRects[3] = CreateBar(parent, "GrabHandle_Right", new Vector2(1f, 0f), Vector2.one, new Vector2(0f, 0.5f), new Vector2(BarThickness, 0f));
+
+            for (int i = 0; i < BarCount; i++)
+            {
+                barImages[i] = barRects[i].GetComponent<Image>();
+            }
+
+            Main.LogEntry("CabDisplay", "Grab handles created around the cab display.");
+        }
+
+        private static RectTransform CreateBar(RectTransform parent, string name, Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Vector2 sizeDelta)
+        {
+            GameObject bar = new(name);
+            bar.transform.SetParent(parent, false);
+
+            Image image = bar.AddComponent<Image>();
+            image.color = IdleColor;
+            image.raycastTarget = false; // the bars are grabbed, never clicked
+
+            RectTransform rect = bar.GetComponent<RectTransform>();
+            rect.anchorMin = anchorMin;
+            rect.anchorMax = anchorMax;
+            rect.pivot = pivot;
+            rect.sizeDelta = sizeDelta;
+            rect.anchoredPosition = Vector2.zero;
+
+            // Deliberately no collider: the display hangs off a locomotive's rigidbody, and any collider
+            // without a body of its own would join that rigidbody and wreck the locomotive's physics.
+            // Hand proximity is measured against the bar rect instead, in DistanceToBar.
+            return rect;
+        }
+
+        private void LateUpdate()
+        {
+            if (panelRect == null)
+            {
+                return;
+            }
+
+            if (!Settings.Instance.cabDisplayGrabHandles || !VRManager.IsVREnabled())
+            {
+                if (holdingHand != null)
+                {
+                    Release();
+                }
+                SetBarsVisible(false);
+                return;
+            }
+
+            SetBarsVisible(true);
+            FindControllers();
+
+            if (holdingHand != null)
+            {
+                if (holdingEvents == null || !holdingEvents.gripPressed || !holdingHand.gameObject.activeInHierarchy)
+                {
+                    Release();
+                }
+                else
+                {
+                    transform.SetPositionAndRotation(
+                        holdingHand.position + holdingHand.rotation * holdOffsetPosition,
+                        holdingHand.rotation * holdOffsetRotation);
+                    return;
+                }
+            }
+
+            UpdateHighlightAndGrab();
+        }
+
+        /// <summary>
+        /// Highlights whichever bar is nearest to either hand, and starts carrying the display if that hand grips.
+        /// </summary>
+        private void UpdateHighlightAndGrab()
+        {
+            int nearestBar = -1;
+            float nearestDistance = ReachDistance;
+            Transform? nearestHand = null;
+            VRTK_ControllerEvents? nearestEvents = null;
+
+            for (int hand = 0; hand < 2; hand++)
+            {
+                Transform? handTransform = hand == 0 ? leftHand : rightHand;
+                if (handTransform == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < BarCount; i++)
+                {
+                    RectTransform bar = barRects[i];
+                    if (bar == null)
+                    {
+                        continue;
+                    }
+
+                    float distance = DistanceToBar(bar, handTransform.position);
+                    if (distance < nearestDistance)
+                    {
+                        nearestDistance = distance;
+                        nearestBar = i;
+                        nearestHand = handTransform;
+                        nearestEvents = hand == 0 ? leftEvents : rightEvents;
+                    }
+                }
+            }
+
+            if (nearestBar != highlightedBar)
+            {
+                if (highlightedBar >= 0 && barImages[highlightedBar] != null)
+                {
+                    barImages[highlightedBar].color = IdleColor;
+                }
+                if (nearestBar >= 0 && barImages[nearestBar] != null)
+                {
+                    barImages[nearestBar].color = ReadyColor;
+                }
+                highlightedBar = nearestBar;
+            }
+
+            if (nearestBar >= 0 && nearestHand != null && nearestEvents != null && nearestEvents.gripPressed)
+            {
+                Grab(nearestHand, nearestEvents, nearestBar);
+            }
+        }
+
+        private void Grab(Transform hand, VRTK_ControllerEvents events, int bar)
+        {
+            bool leftHanded = hand == leftHand;
+            holdingHand = hand;
+            holdingEvents = events;
+            holdOffsetPosition = Quaternion.Inverse(hand.rotation) * (transform.position - hand.position);
+            holdOffsetRotation = Quaternion.Inverse(hand.rotation) * transform.rotation;
+
+            if (barImages[bar] != null)
+            {
+                barImages[bar].color = HeldColor;
+            }
+
+            Main.LogEntry("CabDisplay", $"Cab display picked up by the {(leftHanded ? "left" : "right")} hand.");
+        }
+
+        private void Release()
+        {
+            holdingHand = null;
+            holdingEvents = null;
+            highlightedBar = -1;
+
+            for (int i = 0; i < BarCount; i++)
+            {
+                if (barImages[i] != null)
+                {
+                    barImages[i].color = IdleColor;
+                }
+            }
+
+            released?.Invoke();
+        }
+
+        /// <summary>
+        /// Distance in metres from a hand to the nearest point of a bar, treating the bar as a slab
+        /// <see cref="BarDepth"/> deep. Done in the bar's own space, so it follows the panel as it is resized,
+        /// rescaled and moved without any physics involvement.
+        /// </summary>
+        private static float DistanceToBar(RectTransform bar, Vector3 handPosition)
+        {
+            Vector3 local = bar.InverseTransformPoint(handPosition);
+            Rect area = bar.rect;
+
+            Vector3 nearest = new(
+                Mathf.Clamp(local.x, area.xMin, area.xMax),
+                Mathf.Clamp(local.y, area.yMin, area.yMax),
+                Mathf.Clamp(local.z, -BarDepth * 0.5f, BarDepth * 0.5f));
+
+            return Vector3.Distance(bar.TransformPoint(nearest), handPosition);
+        }
+
+        private void SetBarsVisible(bool visible)
+        {
+            if (visible == barsVisible)
+            {
+                return;
+            }
+            barsVisible = visible;
+
+            for (int i = 0; i < BarCount; i++)
+            {
+                if (barRects[i] != null)
+                {
+                    barRects[i].gameObject.SetActive(visible);
+                }
+            }
+        }
+
+        private void FindControllers()
+        {
+            if (leftHand != null && rightHand != null)
+            {
+                return;
+            }
+            if (Time.unscaledTime < nextControllerSearch)
+            {
+                return;
+            }
+            nextControllerSearch = Time.unscaledTime + ControllerSearchInterval;
+
+            if (leftHand == null)
+            {
+                Resolve(VRTK_DeviceFinder.GetControllerLeftHand(false), VRTK_DeviceFinder.GetControllerLeftHand(true), ref leftHand, ref leftEvents);
+            }
+            if (rightHand == null)
+            {
+                Resolve(VRTK_DeviceFinder.GetControllerRightHand(false), VRTK_DeviceFinder.GetControllerRightHand(true), ref rightHand, ref rightEvents);
+            }
+        }
+
+        /// <summary>
+        /// Takes the controller transform and its button events, preferring the script alias object that carries
+        /// the events and falling back to the actual controller. Leaves both null until the events turn up, so a
+        /// hand is never tracked without a grip button to go with it.
+        /// </summary>
+        private static void Resolve(GameObject? alias, GameObject? actual, ref Transform? hand, ref VRTK_ControllerEvents? events)
+        {
+            GameObject? source = alias != null ? alias : actual;
+            if (source == null)
+            {
+                return;
+            }
+
+            VRTK_ControllerEvents? found = source.GetComponentInChildren<VRTK_ControllerEvents>(true);
+            if (found == null && actual != null)
+            {
+                found = actual.GetComponentInChildren<VRTK_ControllerEvents>(true);
+            }
+            if (found == null)
+            {
+                return;
+            }
+
+            hand = source.transform;
+            events = found;
+        }
+    }
+}

--- a/PanelHost.cs
+++ b/PanelHost.cs
@@ -1,4 +1,3 @@
-using DV.CabControls;
 using TwitchChat.PanelDisplays;
 using TwitchChat.PanelMenus;
 using UnityEngine;
@@ -7,8 +6,8 @@ namespace TwitchChat
 {
     /// <summary>
     /// A surface that carries the mod's full panel stack: one world-space canvas plus an instance of
-    /// every menu and display panel. Concrete hosts decide where the canvas lives (a license paper,
-    /// the locomotive cab, or the player's wrist) and where the active panel choice is persisted.
+    /// every menu and display panel. Concrete hosts decide where the canvas lives (the locomotive cab
+    /// or the player's wrist) and where the active panel choice is persisted.
     /// </summary>
     public abstract class PanelHost
     {
@@ -40,54 +39,6 @@ namespace TwitchChat
 
         /// <summary>Name of the panel currently shown on this host. Persisted in settings.</summary>
         public abstract string ActivePanel { get; set; }
-    }
-
-    /// <summary>
-    /// Legacy host: the canvas rides on one of the player's license papers and hides the printed page.
-    /// </summary>
-    public class LicenseHost : PanelHost
-    {
-        /// <summary>Slot in <see cref="Settings.activePanels"/> that remembers this host's panel.</summary>
-        public int LicenseIndex { get; }
-
-        /// <summary>The prefab name the game reports for this license item; identical to <see cref="PanelHost.Name"/>.</summary>
-        public string PrefabName => Name;
-
-        /// <summary>The live item component, or null until the item has been found in the world.</summary>
-        public ItemBase? Item { get; set; }
-
-        /// <summary>The license GameObject the canvas follows.</summary>
-        public GameObject? LicenseObject { get; set; }
-
-        /// <summary>The printed page renderer that is kept hidden while the canvas covers it.</summary>
-        public Renderer? PaperRenderer { get; set; }
-
-        /// <summary>Fallback paper object for prefabs without a Page component.</summary>
-        public GameObject? PaperObject { get; set; }
-
-        public bool AttachedToStickyTape { get; set; }
-        public GameObject? StickyTapeBase { get; set; }
-
-        public LicenseHost(string prefabName, int index) : base(prefabName)
-        {
-            LicenseIndex = index;
-        }
-
-        public override string ActivePanel
-        {
-            get
-            {
-                string[] panels = Settings.Instance.activePanels;
-                return LicenseIndex < panels.Length && !string.IsNullOrEmpty(panels[LicenseIndex]) ? panels[LicenseIndex] : "Main";
-            }
-            set
-            {
-                if (LicenseIndex < Settings.Instance.activePanels.Length)
-                {
-                    Settings.Instance.activePanels[LicenseIndex] = value;
-                }
-            }
-        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - Integration with "Remote Dispatch" mod
 - Colored announcement system for timed messages
 - Display panel scrolling in VR
-- Choose which licenses to replace with TwitchChat mod menus (currently 'hard coded')
 
 ## Installation
 
@@ -40,27 +39,24 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 
 ### Display and Menu Panel Setup
 
-The menus and chat displays live on world-space panels. There are three kinds of panel host:
+The menus and chat displays live on world-space panels. There are two kinds of panel host:
 
 - **Cab display** - a panel parented to the locomotive you are in, so it rides along with the cab
 -- Press the place key (default F7), or use the "Place Display" button on any Main panel, and the panel appears where you are looking
 -- The position is remembered per locomotive type and restored automatically the next time you board that type
 -- The toggle key (default F8), or the "Toggle Display" button, hides and shows it without moving it
--- Keys, placement distance and scale are set in the Unity Mod Manager menu
+-- In VR, faint grab bars run along all four edges: bring a hand to one (it lights up) and squeeze the grip to carry the display around, exactly like holding the old license papers. Let go and the new spot is saved for that locomotive
+-- Keys, placement distance and scale are set in the Unity Mod Manager menu, where the grab bars can also be turned off
 - **Wrist panel** (VR only) - a smaller copy of the menus attached to a controller, glance at it like a watch
 -- Choose the hand, size, offset and rotation in the Unity Mod Manager menu; changes apply live
 -- Its "Place Display" button is the VR way to summon the cab display without a keyboard
-- **License papers** (legacy mode, can be turned off in the Unity Mod Manager menu) - menus replace the following licenses:
--- LicenseTrainDriver, LicenseShunting, LicenseLocomotiveDE2 - given at the start of a new game
--- LicenseMuseumCitySouth, LicenseFreightHaul, LicenseDispatcher1 - purchase/own the license
--- As these menus ride on licenses, they can be attached to sticky tape anywhere sticky tape can be placed
 
 - Every host shows the same panels and remembers which panel it last showed
 - Display Panels:
 -- Wide - Little wider than the large, but about 1/3 in height
 -- Large - Approx same size as the DE2 back window
--- Medium - About double the license size
--- Small - Same size as the license
+-- Medium - Roughly half a metre square
+-- Small - About the size of a sheet of paper
 - Config Panels
 -- Config1 - Customize background panel and section coloring
 -- Config2 - Customize button coloring and reset color customizations
@@ -177,6 +173,9 @@ Access advanced options by expanding the "Debug and Troubleshooting" section in 
 - Fixed the access token being written to the mod debug log on every authorization
 - Tokens are now encrypted at rest with Windows DPAPI where the runtime supports it, instead of being merely base64 encoded
 - The Twitch username setting is gone. Your account is identified from the token itself
+- The license paper menus are gone. The cab display and wrist panel replace them, so the mod no longer touches your license items or the sticky tape they were stuck to
+- The cab display can be grabbed and moved by hand in VR: grab bars along its four edges light up as a hand nears them, and squeezing the grip carries the display until you let go
+- Fixed the panels interfering with locomotive physics. Their VR colliders had no body of their own, so the game folded them into the rigidbody of the locomotive the display was parented to, which could shift its mass and shove it around. All panel colliders are triggers now, and the grab bars use none at all
 
 ### 3.3.0 (September 4, 2026)
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -51,7 +51,6 @@ namespace TwitchChat
         /// <summary>Refresh token, written by <see cref="TokenStore"/>. Never log this.</summary>
         public string EncodedRefreshToken = string.Empty;
         public DebugLevel debugLevel = DebugLevel.Minimal;
-        public string[] activePanels = ["Main", "Main", "Main", "Main", "Main", "Main"];
         public bool notificationsEnabled = true;
         public float notificationDuration = 10;
         public bool processOwn = true;
@@ -63,11 +62,11 @@ namespace TwitchChat
         public Color buttonColor = new(0, 0, 0, 0.5f);
 
         // Cab Display and Wrist Panel Settings
-        public bool licensePanelsEnabled = true;
         public string cabDisplayPanel = "Main";
         public bool cabDisplayVisible = true;
         public float cabDisplayDistance = 0.7f;
         public float cabDisplayScale = 1.0f;
+        public bool cabDisplayGrabHandles = true;
         public string placeDisplayKey = "F7";
         public string toggleDisplayKey = "F8";
         public List<CabDisplayPose> cabDisplayPoses = new();
@@ -431,8 +430,7 @@ namespace TwitchChat
                 GUILayout.EndHorizontal();
                 cabDisplayDistance = SliderRow("Placement distance (m)", cabDisplayDistance, 0.3f, 2.0f, "0.00");
                 cabDisplayScale = SliderRow("Cab display scale", cabDisplayScale, 0.5f, 2.0f, "0.00");
-                GUILayout.Space(5);
-                licensePanelsEnabled = GUILayout.Toggle(licensePanelsEnabled, " Also show the menus on the six license papers (legacy mode)");
+                cabDisplayGrabHandles = GUILayout.Toggle(cabDisplayGrabHandles, " Grab bars around the cab display (VR only: squeeze the grip on a bar to move it)");
                 GUILayout.Space(5);
                 wristPanelEnabled = GUILayout.Toggle(wristPanelEnabled, " Wrist panel (VR only)");
                 GUILayout.BeginHorizontal();


### PR DESCRIPTION
Three related changes to the in-game panels, on top of the merged v3.4.0 work.

## Drop the legacy license paper menus

The cab display and wrist panel have replaced them, so the legacy host is gone: `LicenseHost`, the storage-system scan for the six license items, the printed-page hiding, and the sticky-tape tracking. `Settings.activePanels` and `licensePanelsEnabled` go with it, along with the UMM toggle and the `LicenseScan` / `HandleLicenseAttachment` log sources.

That machinery is what broke on Build 99, and nothing depends on it now. Existing `settings.xml` files keep working: UMM deserializes with `XmlSerializer`, so the stale elements are ignored on load and dropped on the next save.

## Grab bars for the cab display in VR

Faint bars along the panel's four edges light up as a hand nears one; squeezing the grip carries the display, position and rotation both, until it is let go. The new pose is then saved for that locomotive type, exactly as placing with F7 does. It answers the one thing the license papers did better than the cab display: you could just pick them up.

Hand tracking reads only `VRTK_DeviceFinder` and `VRTK_ControllerEvents.gripPressed`, deliberately staying clear of the game's item and grab systems (`VRTK_InteractGrab_DV`, `GrabHandler`, `ItemBase`) — that coupling is what made the old menus fragile across game builds. New `cabDisplayGrabHandles` setting, default on, with a UMM toggle.

## Fix the panels disturbing locomotive physics

**This one predates the grab bars and affects the released v3.3.0.**

A collider with no rigidbody of its own is absorbed by the nearest rigidbody above it in the hierarchy. The cab display parents to `car.interior`, under the locomotive's rigidbody — so every VR collider on that canvas was being folded into the locomotive's compound collider. That shifts the loco's mass and inertia tensor, lets panel geometry generate real contact forces against the world, and makes PhysX recompute the whole body every time the canvas is activated or deactivated. In game this showed up as a stationary locomotive wandering off, and a jolt each time Toggle Display was pressed.

Two fixes:

- Button, toggle and slider colliders are now `isTrigger = true`. PhysX excludes trigger shapes from both contact generation and mass calculation. Hand touch is unaffected: VRTK and DV both detect it via `OnTriggerEnter/Stay/Exit`, which fire for trigger-vs-trigger because the controller carries its own rigidbody.
- The grab bars create no colliders at all. Proximity is measured analytically in `DistanceToBar` — transform the hand into the bar's space, clamp to the rect and to ±half depth, measure back in world space.

Nothing persists in a save; the corruption lived only in the runtime rigidbody, so a fresh load with this build starts clean.

## Notes for review

- Branched from `main` rather than continuing `v3.3.0-build99-compat-and-panel-hosts`. That branch's earlier commits are already in `main` as squashes, so a PR from it would have shown ~2,900 lines of already-merged diff. Same tree, one commit.
- **Not yet tested in VR.** Two things to confirm in game: that the loco stays put with the display placed and while toggling it, and that panel buttons still respond to hands — the trigger change is the one thing that could plausibly affect the latter, and the symptom would be buttons ignoring touch entirely.
- If grabbing feels like you have to push your hand into the panel, DV's hand model sits offset from the controller alias transform; `ReachDistance` (8 cm) and `BarDepth` (4 cm) in `PanelGrabHandles.cs` are the knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
