### PR TITLE
Put the wrist panel on the hand, and let it be placed by hand (v3.4.2)

### DIFF
--- a/MenuManager.cs
+++ b/MenuManager.cs
@@ -17,7 +17,8 @@ namespace TwitchChat
     /// - Cab displays: up to <see cref="Settings.MaxDisplaysPerCar"/> canvases parented to the current locomotive
     ///   interior, each placed where the player is looking. Each one remembers its own pose, size, panel and locks
     ///   against the locomotive type, and the whole set is restored when the player boards that type again.
-    /// - Wrist panel: one canvas parented to a VR controller so it can be glanced at like a watch.
+    /// - Wrist panel: one canvas on the pad on the back of a VR hand, resting as a small button until the player
+    ///   presses it, so it can be glanced at like a watch.
     /// </remarks>
     public class MenuManager : MonoBehaviour
     {
@@ -36,6 +37,37 @@ namespace TwitchChat
         /// <summary>Largest a display can be dragged, in canvas units. At scale 1 that is 2 by 1.4 metres.</summary>
         public static readonly Vector2 MaxPanelSize = new(2000f, 1400f);
 
+        /// <summary>
+        /// How big the collapsed wrist button is, in canvas units. Small enough to sit on the back of a hand
+        /// without covering it, but still a comfortable target for a VR fingertip.
+        /// </summary>
+        private static readonly Vector2 WristButtonSize = new(96f, 40f);
+
+        /// <summary>How far the panel floats off the back of the hand, in metres, so it does not clip the glove.</summary>
+        private const float WristSurfaceLift = 0.005f;
+
+        /// <summary>
+        /// Where the two wrist surfaces sit on the game's hand pad, in the pad's own space: metres from it, and
+        /// how they are turned against it. Measured by placing them by hand in VR on a Quest 3, and good for any
+        /// controller, since the pad is the same object on every hand however the game fits that hand to the
+        /// controller. The rotations are kept as the fit they were measured against times the turn that was
+        /// made from it, which is exactly what produced them, rather than a single number worked out by hand.
+        /// The player's own placement is applied on top of these.
+        /// </summary>
+        private static readonly Vector3 PadMenuPosition = new(-0.0614f, 0.0813f, 0.0658f);
+        private static readonly Quaternion PadMenuRotation = Quaternion.Euler(270f, 180f, 0f) * Quaternion.Euler(38.4911f, -177.0492f, 19.1316f);
+        private static readonly Vector3 PadButtonPosition = new(-0.0963f, 0.0804f, -0.0863f);
+        private static readonly Quaternion PadButtonRotation = Quaternion.Euler(270f, 180f, 0f) * Quaternion.Euler(10.2575f, -83.4423f, 67.3378f);
+
+        /// <summary>How many searches to give the game's hand pad before settling for the bare controller pose.</summary>
+        private const int WristPadAttempts = 5;
+
+        /// <summary>
+        /// Gap in canvas units between the anchor on the back of the hand and the near edge of the open menus,
+        /// which unfold back down the forearm rather than sitting on top of the hand.
+        /// </summary>
+        private const float WristMenuGap = 10f;
+
         private static MenuManager? instance;
 
         /// <summary>The displays live in the locomotive the player is in, one per saved slot for its type.</summary>
@@ -44,8 +76,29 @@ namespace TwitchChat
         private GameObject? templateCanvas;
 
         private TrainCar? cabDisplayCar;
+
+        /// <summary>What the wrist canvas is parented to: the pad on the back of the hand, or the controller.</summary>
         private Transform? wristAnchor;
         private float nextWristSearchTime;
+        private int wristAnchorAttempts;
+
+        /// <summary>True while the canvas is on the hand pad rather than making do with the controller pose.</summary>
+        private bool wristOnPad;
+
+        /// <summary>Carries the open menus around while the player is placing them, on the canvas that holds them.</summary>
+        private WristPanelGrab? wristGrab;
+
+        /// <summary>The same for the button the menus fold down to, which is placed on the hand separately.</summary>
+        private WristPanelGrab? wristButtonGrab;
+
+        private string wristAnchorSummary = "nothing yet";
+
+        /// <summary>What the wrist panel is hanging off, in a few words, for the panel that places it.</summary>
+        public string WristAnchorSummary => wristAnchorSummary;
+
+        /// <summary>How each surface sits on the anchor before the player's own placement is applied.</summary>
+        private WristFit menuFit;
+        private WristFit buttonFit;
 
         private KeyCode placeKey = KeyCode.None;
         private KeyCode toggleKey = KeyCode.None;
@@ -65,6 +118,13 @@ namespace TwitchChat
             }
         }
 
+        /// <summary>How a wrist surface sits on its anchor, in the anchor's own space, before any placement.</summary>
+        private struct WristFit
+        {
+            public Vector3 Position;
+            public Quaternion Rotation;
+        }
+
         /// <summary>
         /// Defines the types of panels available in the mod interface.
         /// </summary>
@@ -81,6 +141,7 @@ namespace TwitchChat
             Config1,
             Config2,
             Displays,
+            WristAdjust,
             Debug
         }
 
@@ -174,6 +235,7 @@ namespace TwitchChat
             _ = new Config1Panel(parent);
             _ = new Config2Panel(parent);
             _ = new DisplaysPanel(parent);
+            _ = new WristAdjustPanel(parent);
             _ = new DebugPanel(parent);
 
             // Hide all template panels
@@ -200,6 +262,7 @@ namespace TwitchChat
 
         private void LateUpdate()
         {
+            // Whichever surface a hand is carrying is left where that hand has it; ApplyWristPose sees to that
             if (wristAnchor != null && wristPanel.MenuCanvas != null && wristPanel.MenuCanvas.activeSelf)
             {
                 ApplyWristPose();
@@ -551,9 +614,13 @@ namespace TwitchChat
                 {
                     wristPanel.MenuCanvas.SetActive(false);
                 }
+                if (wristPanel.ButtonCanvas != null && wristPanel.ButtonCanvas.activeSelf)
+                {
+                    wristPanel.ButtonCanvas.SetActive(false);
+                }
                 if (!inSession)
                 {
-                    wristAnchor = null;
+                    ClearWristAnchor();
                 }
                 return;
             }
@@ -561,27 +628,21 @@ namespace TwitchChat
             if (wristPanel.MenuCanvas == null)
             {
                 CreateMenuCanvas(wristPanel);
-                wristAnchor = null;
+                ClearWristAnchor();
             }
 
             bool wantLeft = Settings.Instance.wristPanelOnLeftHand;
             if (wristAnchor != null && wristPanel.AttachedToLeftHand != wantLeft)
             {
-                wristAnchor = null; // hand preference changed, re-attach
+                ClearWristAnchor(); // hand preference changed, re-attach
             }
 
-            if (wristAnchor == null && Time.unscaledTime >= nextWristSearchTime)
+            // Keep looking while there is no anchor at all, and while making do with the controller, so the
+            // panel moves onto the hand pad as soon as the game has built the hands
+            if ((wristAnchor == null || !wristOnPad) && Time.unscaledTime >= nextWristSearchTime)
             {
                 nextWristSearchTime = Time.unscaledTime + WristSearchInterval;
-                GameObject? hand = wantLeft ? VRTK_DeviceFinder.GetControllerLeftHand(true) : VRTK_DeviceFinder.GetControllerRightHand(true);
-                if (hand != null)
-                {
-                    wristAnchor = hand.transform;
-                    wristPanel.AttachedToLeftHand = wantLeft;
-                    wristPanel.MenuCanvas!.transform.SetParent(wristAnchor, false);
-                    ApplyWristPose();
-                    Main.LogEntry("WristPanel", $"Wrist panel attached to the {(wantLeft ? "left" : "right")} controller ('{hand.name}').");
-                }
+                TryAttachWristPanel(wantLeft);
             }
 
             GameObject canvas = wristPanel.MenuCanvas!;
@@ -591,26 +652,435 @@ namespace TwitchChat
                 canvas.SetActive(shouldShow);
                 if (shouldShow)
                 {
-                    ShowPanel(wristPanel.ActivePanel, wristPanel);
+                    ApplyWristExpansion();
                 }
             }
 
-            if (shouldShow)
+            UpdateWristPlacing(shouldShow);
+
+            // Only the open menus need feeding; while collapsed there is nothing on show but the button
+            if (shouldShow && wristPanel.Expanded)
             {
                 UpdatePanelValues(wristPanel);
             }
         }
 
-        private void ApplyWristPose()
+        /// <summary>
+        /// Decides which of the two surfaces, if either, is being placed at the moment, and shows the button
+        /// alongside the menus while it is the one being placed so the player can see where it is going.
+        /// </summary>
+        private void UpdateWristPlacing(bool attached)
+        {
+            bool adjusting = attached && WristAdjustShowing();
+            bool placingButton = adjusting && PlacingWristButton;
+
+            if (wristGrab != null)
+            {
+                // Only ever carry what can be seen: the menus are only on show while the panel is open
+                wristGrab.AdjustMode = adjusting && !PlacingWristButton && wristPanel.Expanded;
+            }
+            if (wristButtonGrab != null)
+            {
+                wristButtonGrab.AdjustMode = placingButton;
+            }
+
+            if (wristPanel.ButtonCanvas == null)
+            {
+                return;
+            }
+
+            bool showButton = attached && (!wristPanel.Expanded || placingButton);
+            if (wristPanel.ButtonCanvas.activeSelf != showButton)
+            {
+                wristPanel.ButtonCanvas.SetActive(showButton);
+            }
+        }
+
+        /// <summary>True while some host has the panel that places the wrist panel on show.</summary>
+        private bool WristAdjustShowing()
+        {
+            foreach (PanelHost host in AllHosts)
+            {
+                if (host.MenuCanvas == null || !host.MenuCanvas.activeSelf || host.ActivePanel != "Wrist Adjust")
+                {
+                    continue;
+                }
+                if (host is WristPanelHost wrist && !wrist.Expanded)
+                {
+                    continue; // folded away, so nothing is on show to place from
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>Which of the wrist panel's two surfaces the adjust panel is placing.</summary>
+        public bool PlacingWristButton { get; private set; }
+
+        /// <summary>Switches the adjust panel between placing the open menus and placing the button.</summary>
+        public void SetPlacingWristButton(bool button)
+        {
+            PlacingWristButton = button;
+            Main.LogEntry("WristPanel", button ? "Now placing the hand button." : "Now placing the floating menus.");
+        }
+
+        /// <summary>
+        /// Opens the wrist menus, or folds them back down into the button.
+        /// </summary>
+        private void SetWristExpanded(bool expanded)
+        {
+            wristPanel.Expanded = expanded;
+            ApplyWristExpansion();
+            Main.LogEntry("WristPanel", expanded ? "Wrist panel opened." : "Wrist panel collapsed back to its button.");
+        }
+
+        /// <summary>
+        /// Shows either the panel stack or the collapsed button, whichever state the wrist panel is in.
+        /// </summary>
+        private void ApplyWristExpansion()
         {
             if (wristPanel.MenuCanvas == null)
             {
                 return;
             }
-            Transform canvas = wristPanel.MenuCanvas.transform;
-            canvas.localPosition = Settings.Instance.wristPanelOffset;
-            canvas.localRotation = Quaternion.Euler(Settings.Instance.wristPanelRotation);
-            canvas.localScale = Vector3.one * BaseCanvasScale * Settings.Instance.wristPanelScale;
+
+            Transform? menuPanel = wristPanel.MenuCanvas.transform.Find("MenuPanel");
+            if (menuPanel != null)
+            {
+                menuPanel.gameObject.SetActive(wristPanel.Expanded);
+            }
+
+            if (wristPanel.Expanded)
+            {
+                ShowPanel(wristPanel.ActivePanel, wristPanel);
+            }
+        }
+
+        /// <summary>
+        /// Builds the button the wrist panel rests as, on a canvas of its own so it can be placed on the hand
+        /// separately from the menus. Pressing it opens them.
+        /// </summary>
+        private void CreateWristButton(WristPanelHost host)
+        {
+            if (host.MenuCanvas == null)
+            {
+                return;
+            }
+
+            if (host.ButtonCanvas != null)
+            {
+                Destroy(host.ButtonCanvas); // the menus have been rebuilt, so the button is rebuilt with them
+                host.ButtonCanvas = null;
+            }
+
+            GameObject buttonCanvas = new("MenuCanvas_WristButton");
+            Canvas canvasComponent = buttonCanvas.AddComponent<Canvas>();
+            canvasComponent.renderMode = RenderMode.WorldSpace;
+            canvasComponent.sortingOrder = 1000;
+            buttonCanvas.AddComponent<GraphicRaycaster>();
+
+            RectTransform canvasRect = buttonCanvas.GetComponent<RectTransform>();
+            canvasRect.sizeDelta = WristButtonSize;
+
+            Button button = PanelConstructor.Button.Create(
+                buttonCanvas.transform,
+                "TwitchChat",
+                0,
+                0,
+                Color.white,
+                () => SetWristExpanded(true));
+
+            RectTransform rect = button.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = WristButtonSize;
+            rect.anchoredPosition = Vector2.zero;
+
+            // The collider is sized from the button's text, so widen it to the button we have just made
+            BoxCollider? collider = button.GetComponent<BoxCollider>();
+            if (collider != null)
+            {
+                collider.size = new Vector3(WristButtonSize.x, WristButtonSize.y, 1f);
+            }
+
+            Text? label = button.GetComponentInChildren<Text>();
+            if (label != null)
+            {
+                label.fontSize = 16;
+            }
+
+            wristButtonGrab = buttonCanvas.AddComponent<WristPanelGrab>();
+            wristButtonGrab.Initialize(() => OnWristSurfacePlaced(true));
+            wristButtonGrab.WornOnLeft = host.AttachedToLeftHand;
+
+            host.ButtonCanvas = buttonCanvas;
+            buttonCanvas.SetActive(!host.Expanded);
+        }
+
+        /// <summary>
+        /// Puts the menus and the button where their own settings say, unless a hand is busy carrying one.
+        /// </summary>
+        private void ApplyWristPose()
+        {
+            if (wristAnchor == null)
+            {
+                return;
+            }
+
+            if (wristPanel.MenuCanvas != null && (wristGrab == null || !wristGrab.IsHeld))
+            {
+                PoseWristSurface(wristPanel.MenuCanvas.transform, menuFit, Settings.Instance.wristMenuOffset, Settings.Instance.wristMenuAngle);
+            }
+
+            if (wristPanel.ButtonCanvas != null && (wristButtonGrab == null || !wristButtonGrab.IsHeld))
+            {
+                PoseWristSurface(wristPanel.ButtonCanvas.transform, buttonFit, Settings.Instance.wristButtonOffset, Settings.Instance.wristButtonAngle);
+            }
+        }
+
+        /// <summary>
+        /// Sits one canvas on the hand: where its measured fit puts it, then moved and turned by its settings.
+        /// </summary>
+        private void PoseWristSurface(Transform canvas, WristFit fit, Vector3 nudge, Vector3 tilt)
+        {
+            // The anchor belongs to the game, so it may well be scaled, and the hand pad is built at a tenth of
+            // a unit. Divide that back out, or the panel comes out a tenth of the size it should be.
+            float anchorScale = Mathf.Max(0.0001f, wristAnchor!.lossyScale.x);
+
+            // The nudge is in the surface's own directions: x across it, y along it, z out of the hand
+            Vector3 offset = fit.Position + (fit.Rotation * new Vector3(nudge.x, nudge.y, -nudge.z));
+
+            canvas.localPosition = offset / anchorScale;
+            canvas.localRotation = fit.Rotation * Quaternion.Euler(tilt);
+            canvas.localScale = Vector3.one * (BaseCanvasScale * Settings.Instance.wristPanelScale / anchorScale);
+        }
+
+        /// <summary>
+        /// Parents the canvas to the sticky pad on the back of the chosen hand, which is where the game itself
+        /// puts anything the player is carrying, and squares the panel up with it. Falls back to the bare
+        /// controller pose if the pad never turns up.
+        /// </summary>
+        private void TryAttachWristPanel(bool wantLeft)
+        {
+            GameObject? controller = wantLeft
+                ? VRTK_DeviceFinder.GetControllerLeftHand(true)
+                : VRTK_DeviceFinder.GetControllerRightHand(true);
+            if (controller == null || wristPanel.MenuCanvas == null)
+            {
+                return;
+            }
+
+            wristAnchorAttempts++;
+            Transform? pad = FindHandPad(wantLeft, controller);
+            bool onPad = pad != null;
+
+            // The hands are built a moment after the controllers appear, so give the pad a few tries to show up.
+            // Once we have settled for the controller there is nothing to redo until the pad finally appears.
+            if (!onPad && (wristAnchor != null || wristAnchorAttempts < WristPadAttempts))
+            {
+                return;
+            }
+
+            Transform anchor = onPad ? pad! : controller.transform;
+            AlignWristPanel(anchor, controller.transform, onPad);
+
+            wristAnchor = anchor;
+            wristOnPad = onPad;
+            wristPanel.AttachedToLeftHand = wantLeft;
+            wristPanel.MenuCanvas.transform.SetParent(anchor, false);
+            wristPanel.ButtonCanvas?.transform.SetParent(anchor, false);
+            ApplyWristPose();
+
+            string hand = wantLeft ? "left" : "right";
+            wristAnchorSummary = onPad ? $"{hand} hand pad" : $"{hand} controller, no pad";
+            if (wristGrab != null)
+            {
+                wristGrab.WornOnLeft = wantLeft;
+            }
+            if (wristButtonGrab != null)
+            {
+                wristButtonGrab.WornOnLeft = wantLeft;
+            }
+
+            Main.LogEntry("WristPanel", onPad
+                ? $"Wrist panel attached to the {hand} hand pad ('{anchor.name}'), scale {anchor.lossyScale}."
+                : $"No {hand} hand pad found, so the wrist panel fell back to the controller ('{anchor.name}').");
+        }
+
+        /// <summary>
+        /// Finds the pad on the back of a hand. The game's own lookup is the first choice, but it answers from
+        /// a cache that is only filled once it has built the hands, so failing that the pad is looked for by
+        /// name under the controller.
+        /// </summary>
+        private static Transform? FindHandPad(bool wantLeft, GameObject controller)
+        {
+            try
+            {
+                Transform? pad = PipaUtils.PipaTransform(wantLeft
+                    ? SDK_BaseController.ControllerHand.Left
+                    : SDK_BaseController.ControllerHand.Right);
+                if (pad != null)
+                {
+                    return pad;
+                }
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("WristPanel", $"The game could not name its hand pad: {ex.Message}");
+            }
+
+            string exact = wantLeft ? "[pipa l]" : "[pipa r]";
+            Transform? loose = null;
+
+            foreach (Transform child in controller.GetComponentsInChildren<Transform>(true))
+            {
+                if (!child.gameObject.activeInHierarchy)
+                {
+                    continue;
+                }
+
+                string name = child.name.ToLowerInvariant();
+                if (name == exact || name == "[pipa]")
+                {
+                    return child;
+                }
+                if (loose == null && name.Contains("pipa") && !name.Contains("attach"))
+                {
+                    loose = child;
+                }
+            }
+
+            return loose;
+        }
+
+        /// <summary>
+        /// Works out how the panel should sit on its anchor: flat against the back of the hand, facing out of
+        /// it, with the top of the panel towards the fingers. The anchor is the game's, so rather than assume
+        /// which way it was built, each direction is matched to whichever of the anchor's own axes fits it.
+        /// </summary>
+        private void AlignWristPanel(Transform anchor, Transform controller, bool onPad)
+        {
+            if (onPad)
+            {
+                // The pad is the same object on every hand, so how a surface should sit on it is a measurement
+                // rather than a guess
+                menuFit = new WristFit { Position = PadMenuPosition, Rotation = PadMenuRotation };
+                buttonFit = new WristFit { Position = PadButtonPosition, Rotation = PadButtonRotation };
+                return;
+            }
+
+            // Without the pad there is nothing measured to go on, so both surfaces are squared up with the
+            // controller as best it can be guessed: out of its top, with the top of the panel where it points
+            Vector3 normal = NearestLocalAxis(anchor, anchor.up, Vector3.zero);
+            Vector3 up = NearestLocalAxis(anchor, controller.forward, normal);
+
+            // A canvas is read from the side its forward points away from, so aim forward into the hand
+            WristFit guess = new()
+            {
+                Position = normal * WristSurfaceLift,
+                Rotation = Quaternion.LookRotation(-normal, up)
+            };
+
+            menuFit = guess;
+            buttonFit = guess;
+
+            Main.LogEntry("WristPanel", $"No pad to measure against on '{anchor.name}', so both surfaces face out " +
+                $"along its {normal} with {up} towards the fingers, scale {anchor.lossyScale}.");
+        }
+
+        /// <summary>
+        /// Picks whichever of the anchor's own six axis directions points most nearly the way we want, so the
+        /// panel lands square on the anchor however the game happened to build it.
+        /// </summary>
+        /// <param name="anchor">The transform whose axes are being chosen between.</param>
+        /// <param name="worldTarget">The direction being matched, in world space.</param>
+        /// <param name="skip">An axis already spoken for, which rules out that axis and its opposite.</param>
+        /// <returns>The chosen axis, in the anchor's local space.</returns>
+        private static Vector3 NearestLocalAxis(Transform anchor, Vector3 worldTarget, Vector3 skip)
+        {
+            Vector3[] candidates = { Vector3.right, Vector3.left, Vector3.up, Vector3.down, Vector3.forward, Vector3.back };
+            Vector3 target = worldTarget.normalized;
+            Vector3 best = Vector3.up;
+            float bestDot = float.NegativeInfinity;
+
+            foreach (Vector3 candidate in candidates)
+            {
+                if (skip != Vector3.zero && Mathf.Abs(Vector3.Dot(candidate, skip)) > 0.5f)
+                {
+                    continue;
+                }
+
+                float dot = Vector3.Dot(anchor.TransformDirection(candidate).normalized, target);
+                if (dot > bestDot)
+                {
+                    bestDot = dot;
+                    best = candidate;
+                }
+            }
+
+            return best;
+        }
+
+        /// <summary>
+        /// Takes where a hand has just put one of the wrist surfaces and works it back into that surface's own
+        /// settings, so the numbers on the adjust panel, what is saved, and where it actually is all agree.
+        /// </summary>
+        /// <param name="isButton">True for the button, false for the open menus.</param>
+        private void OnWristSurfacePlaced(bool isButton)
+        {
+            GameObject? surface = isButton ? wristPanel.ButtonCanvas : wristPanel.MenuCanvas;
+            if (surface == null || wristAnchor == null)
+            {
+                return;
+            }
+
+            Transform canvas = surface.transform;
+            WristFit fit = isButton ? buttonFit : menuFit;
+            float anchorScale = Mathf.Max(0.0001f, wristAnchor.lossyScale.x);
+
+            // Undo the surface's fit, which leaves exactly the player's own nudge and tilt on top of it
+            Vector3 offset = (canvas.localPosition * anchorScale) - fit.Position;
+            Vector3 inPanel = Quaternion.Inverse(fit.Rotation) * offset;
+            Vector3 nudge = new(inPanel.x, inPanel.y, -inPanel.z);
+
+            Vector3 tilt = (Quaternion.Inverse(fit.Rotation) * canvas.localRotation).eulerAngles;
+            tilt = new Vector3(Mathf.DeltaAngle(0f, tilt.x), Mathf.DeltaAngle(0f, tilt.y), Mathf.DeltaAngle(0f, tilt.z));
+
+            float limit = WristAdjustPanel.MoveLimit;
+            nudge = new Vector3(
+                Mathf.Clamp(nudge.x, -limit, limit),
+                Mathf.Clamp(nudge.y, -limit, limit),
+                Mathf.Clamp(nudge.z, -limit, limit));
+
+            if (isButton)
+            {
+                Settings.Instance.wristButtonOffset = nudge;
+                Settings.Instance.wristButtonAngle = tilt;
+            }
+            else
+            {
+                Settings.Instance.wristMenuOffset = nudge;
+                Settings.Instance.wristMenuAngle = tilt;
+            }
+            Settings.Instance.RequestSave();
+
+            // Snap to what was actually saved, so a surface put out of reach comes back to the edge of its range
+            ApplyWristPose();
+
+            // The whole pose against the anchor as well as the settings, since that is what a new built-in
+            // default would have to be: it does not depend on the placement it was reached from
+            string what = isButton ? "Hand button" : "Floating menus";
+            Main.LogEntry("WristPanel", $"{what} placed by hand: nudge {nudge.ToString("F4")}, tilt {tilt.ToString("F2")}. " +
+                $"On the anchor that is position {(canvas.localPosition * anchorScale).ToString("F4")} m, rotation {canvas.localRotation.eulerAngles.ToString("F2")}.");
+        }
+
+        private void ClearWristAnchor()
+        {
+            wristAnchor = null;
+            wristOnPad = false;
+            wristAnchorAttempts = 0;
         }
 
         // ------------------------------------------------------------------
@@ -626,6 +1096,7 @@ namespace TwitchChat
             host.StatusPanel?.UpdateStatusPanelValues();
             host.StandardMessagesPanel?.UpdateStandardMessagesPanelValues();
             host.CommandMessagesPanel?.UpdateCommandMessagesPanelValues();
+            host.WristAdjustPanel?.UpdateValues();
         }
 
         public void OnPanelButtonClicked(string panelName, PanelHost host)
@@ -660,6 +1131,7 @@ namespace TwitchChat
             host.Config1Panel = new Config1Panel(menuPanel);
             host.Config2Panel = new Config2Panel(menuPanel);
             host.DisplaysPanel = new DisplaysPanel(menuPanel);
+            host.WristAdjustPanel = new WristAdjustPanel(menuPanel);
             host.DebugPanel = new DebugPanel(menuPanel);
 
             // Explicitly hide all panels immediately after creation
@@ -676,6 +1148,7 @@ namespace TwitchChat
             host.Config1Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
             host.Config2Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
             host.DisplaysPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
+            host.WristAdjustPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
             host.DebugPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
 
             // Cab displays are the hosts the player moves and resizes, so they are the ones that get grab bars
@@ -684,6 +1157,26 @@ namespace TwitchChat
                 display.Handles = host.MenuCanvas.AddComponent<PanelGrabHandles>();
                 display.Handles.Initialize(menuPanel, display, () => OnCabDisplayChanged(display));
                 host.SetCloseAction(() => CloseCabDisplay(display));
+            }
+
+            // The wrist panel rests as a button: going back from its main menu folds the menus away again
+            if (host is WristPanelHost wrist)
+            {
+                CreateWristButton(wrist);
+                host.MainPanel.OnBackButtonClicked += () => SetWristExpanded(false);
+
+                wristGrab = host.MenuCanvas.AddComponent<WristPanelGrab>();
+                wristGrab.Initialize(() => OnWristSurfacePlaced(false));
+                wristGrab.Reference = menuPanel;
+                wristGrab.WornOnLeft = wrist.AttachedToLeftHand;
+
+                if (menuPanel != null)
+                {
+                    // The button sits on the back of the hand, so the open menus start there and run back down
+                    // the forearm instead of hanging half inside it
+                    menuPanel.localPosition = new Vector3(0f, -((DefaultPanelSize.y / 2f) + WristMenuGap), 0f);
+                    menuPanel.gameObject.SetActive(wrist.Expanded);
+                }
             }
 
             Main.LogEntry("CreateMenuCanvas", $"Created panel stack for host {host.Name}.");
@@ -702,6 +1195,7 @@ namespace TwitchChat
             host.Config1Panel?.Hide();
             host.Config2Panel?.Hide();
             host.DisplaysPanel?.Hide();
+            host.WristAdjustPanel?.Hide();
             host.DebugPanel?.Hide();
         }
 
@@ -733,9 +1227,11 @@ namespace TwitchChat
                 "Config1" => PanelType.Config1,
                 "Config2" => PanelType.Config2,
                 "Displays" => PanelType.Displays,
+                "Wrist Adjust" => PanelType.WristAdjust,
                 "Debug" => PanelType.Debug,
                 _ => PanelType.Main
             };
+
 
             // Panels have no size of their own: a display keeps whatever size it has been dragged to, whichever
             // panel it shows. A display that has never been sized starts at the default.
@@ -796,6 +1292,9 @@ namespace TwitchChat
                     break;
                 case PanelType.Displays:
                     host.DisplaysPanel?.Show();
+                    break;
+                case PanelType.WristAdjust:
+                    host.WristAdjustPanel?.Show();
                     break;
                 case PanelType.Debug:
                     host.DebugPanel?.Show();

--- a/PanelGrabHandles.cs
+++ b/PanelGrabHandles.cs
@@ -575,9 +575,10 @@ namespace TwitchChat
         /// <summary>
         /// Takes the controller transform and its button events, preferring the script alias object that carries
         /// the events and falling back to the actual controller. Leaves both null until the events turn up, so a
-        /// hand is never tracked without buttons to go with it.
+        /// hand is never tracked without buttons to go with it. Shared with the wrist panel, which picks its
+        /// hands out the same way.
         /// </summary>
-        private static void Resolve(GameObject? alias, GameObject? actual, ref Transform? hand, ref VRTK_ControllerEvents? events)
+        internal static void Resolve(GameObject? alias, GameObject? actual, ref Transform? hand, ref VRTK_ControllerEvents? events)
         {
             GameObject? source = alias != null ? alias : actual;
             if (source == null)

--- a/PanelHost.cs
+++ b/PanelHost.cs
@@ -26,6 +26,7 @@ namespace TwitchChat
         public Config1Panel? Config1Panel { get; set; }
         public Config2Panel? Config2Panel { get; set; }
         public DisplaysPanel? DisplaysPanel { get; set; }
+        public WristAdjustPanel? WristAdjustPanel { get; set; }
         public DebugPanel? DebugPanel { get; set; }
 
         // Panel Displays
@@ -55,6 +56,7 @@ namespace TwitchChat
             Config1Panel?.SetCloseAction(action);
             Config2Panel?.SetCloseAction(action);
             DisplaysPanel?.SetCloseAction(action);
+            WristAdjustPanel?.SetCloseAction(action);
             DebugPanel?.SetCloseAction(action);
             ChatPanel?.SetCloseAction(action);
         }
@@ -88,12 +90,25 @@ namespace TwitchChat
     }
 
     /// <summary>
-    /// Host parented to a VR controller so it sits on the player's forearm like a watch.
+    /// Host parented to the pad on the back of a VR hand, the one the game sticks carried items to, so it sits
+    /// there like a watch. It rests as a small button and only unfolds into the full panel stack when opened.
     /// </summary>
     public class WristPanelHost : PanelHost
     {
         /// <summary>Whether the canvas is currently attached to the left hand (false = right hand).</summary>
         public bool AttachedToLeftHand { get; set; }
+
+        /// <summary>
+        /// The canvas carrying the small button the panel rests as, shown in place of the menus while
+        /// collapsed. It is a canvas of its own so that it can be placed on the hand separately from them.
+        /// </summary>
+        public GameObject? ButtonCanvas { get; set; }
+
+        /// <summary>
+        /// True while the menus are open. Starts false so the panel is out of the way until the player
+        /// presses its button, and going back from the main menu folds it away again.
+        /// </summary>
+        public bool Expanded { get; set; }
 
         public WristPanelHost() : base("WristPanel") { }
 

--- a/PanelMenus/Main.cs
+++ b/PanelMenus/Main.cs
@@ -49,6 +49,9 @@ namespace TwitchChat.PanelMenus
             // Cab display controls side by side
             CreateActionButton("Place Display", 260, -42, () => MenuManager.Instance.PlaceCabDisplay());
             CreateActionButton("Toggle Display", 260, 42, () => MenuManager.Instance.ToggleCabDisplay());
+
+            // Where the wrist panel sits on the hand, adjustable from any host
+            CreateMenuButton("Wrist Adjust", 285);
         }
 
         /// <summary>

--- a/PanelMenus/WristAdjust.cs
+++ b/PanelMenus/WristAdjust.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.PanelMenus
+{
+    /// <summary>
+    /// Places the wrist panel by hand. Six rows slide and turn it against the hand it is attached to, and in VR
+    /// the panel itself can be taken in the free hand and put where it is wanted while this panel is open.
+    /// </summary>
+    /// <remarks>
+    /// The rows step rather than slide because a slider in VR is driven by touching it, which walks the value
+    /// along in tenths and wraps round at the end: no use for lining a panel up on a hand. Every host carries a
+    /// copy, so the wrist panel can also be placed from a cab display, which is easier to press accurately.
+    /// </remarks>
+    public class WristAdjustPanel : PanelConstructor.BasePanel
+    {
+        /// <summary>Metres a move row steps, per press of its fine and its coarse button.</summary>
+        private const float MoveStep = 0.005f;
+        private const float MoveStepCoarse = 0.03f;
+
+        /// <summary>Degrees a turn row steps, per press of its fine and its coarse button.</summary>
+        private const float TurnStep = 5f;
+        private const float TurnStepCoarse = 45f;
+
+        /// <summary>How far from the hand the panel may be put, in metres, however it is placed.</summary>
+        public const float MoveLimit = 0.5f;
+
+        private readonly List<Readout> readouts = new();
+        private Text? anchorLine;
+        private Text? targetLabel;
+        private string anchorSummary = string.Empty;
+        private bool shownPlacingButton;
+
+        public WristAdjustPanel(Transform parent) : base(parent)
+        {
+            CreateRows();
+        }
+
+        private void CreateRows()
+        {
+            anchorLine = PanelConstructor.Label.Create(panelObject.transform, "Attached to:", 6, 24, Color.cyan);
+
+            UnityEngine.UI.Button target = PanelConstructor.Button.Create(
+                panelObject.transform, "Placing: floating menus", 120, 48, Color.white,
+                () => MenuManager.Instance.SetPlacingWristButton(!MenuManager.Instance.PlacingWristButton));
+            targetLabel = target.GetComponentInChildren<Text>();
+
+            CreateRow("Across", 74, MoveStep, MoveStepCoarse, "0.000",
+                () => Nudge.x, value => SetNudge(0, value));
+            CreateRow("Along", 100, MoveStep, MoveStepCoarse, "0.000",
+                () => Nudge.y, value => SetNudge(1, value));
+            CreateRow("Out", 126, MoveStep, MoveStepCoarse, "0.000",
+                () => Nudge.z, value => SetNudge(2, value));
+            CreateRow("Turn X", 156, TurnStep, TurnStepCoarse, "0",
+                () => Tilt.x, value => SetTilt(0, value));
+            CreateRow("Turn Y", 182, TurnStep, TurnStepCoarse, "0",
+                () => Tilt.y, value => SetTilt(1, value));
+            CreateRow("Turn Z", 208, TurnStep, TurnStepCoarse, "0",
+                () => Tilt.z, value => SetTilt(2, value));
+
+            PanelConstructor.Button.Create(panelObject.transform, "Reset this one", 120, 238, Color.white, ResetPlacement);
+
+            PanelConstructor.DisplayText.Create(panelObject.transform,
+                "Metres and degrees, each surface placed on its own. In VR, hold the grip on your free hand next to the one being placed to carry it, and let go where you want it.",
+                8, 258, Color.white, 5, 10);
+        }
+
+        /// <summary>The placement being edited: the button's while that is what is being placed, or the menus'.</summary>
+        private static Vector3 Nudge => MenuManager.Instance.PlacingWristButton
+            ? Settings.Instance.wristButtonOffset
+            : Settings.Instance.wristMenuOffset;
+
+        private static Vector3 Tilt => MenuManager.Instance.PlacingWristButton
+            ? Settings.Instance.wristButtonAngle
+            : Settings.Instance.wristMenuAngle;
+
+        /// <summary>
+        /// Builds one row: a name, a coarse and a fine step either side of the number it is changing.
+        /// </summary>
+        private void CreateRow(string name, int y, float step, float coarseStep, string format, Func<float> read, Action<float> write)
+        {
+            PanelConstructor.Label.Create(panelObject.transform, name, 6, y - 10, Color.white);
+
+            CreateStepButton("<<", 92, y, () => write(read() - coarseStep));
+            CreateStepButton("<", 122, y, () => write(read() - step));
+            CreateStepButton(">", 178, y, () => write(read() + step));
+            CreateStepButton(">>", 208, y, () => write(read() + coarseStep));
+
+            readouts.Add(new Readout(CreateReadout(150, y), read, format));
+        }
+
+        private void CreateStepButton(string text, int x, int y, Action step)
+        {
+            PanelConstructor.Button.Create(panelObject.transform, text, x, y, Color.white, () => step(), 18);
+        }
+
+        private Text CreateReadout(int x, int y)
+        {
+            GameObject fieldObject = new("Value");
+            fieldObject.transform.SetParent(panelObject.transform, false);
+
+            Text field = fieldObject.AddComponent<Text>();
+            field.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            field.fontSize = 12;
+            field.alignment = TextAnchor.MiddleCenter;
+            field.color = Color.cyan;
+
+            RectTransform rect = fieldObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0, 1);
+            rect.anchorMax = new Vector2(0, 1);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = new Vector2(48, 20);
+            rect.anchoredPosition = new Vector2(x, -y);
+
+            return field;
+        }
+
+        /// <summary>
+        /// Redraws the numbers. They move on their own as well as by pressing the rows, since the panel can be
+        /// carried into place by hand, so this runs while the panel is on show.
+        /// </summary>
+        public void UpdateValues()
+        {
+            foreach (Readout readout in readouts)
+            {
+                float value = readout.Read();
+                if (readout.Field == null || Mathf.Approximately(value, readout.Last))
+                {
+                    continue;
+                }
+
+                readout.Last = value;
+                readout.Field.text = value.ToString(readout.Format);
+            }
+
+            string summary = MenuManager.Instance.WristAnchorSummary;
+            if (anchorLine != null && summary != anchorSummary)
+            {
+                anchorSummary = summary;
+                anchorLine.text = "Attached to: " + summary;
+            }
+
+            bool placingButton = MenuManager.Instance.PlacingWristButton;
+            if (targetLabel != null && placingButton != shownPlacingButton)
+            {
+                shownPlacingButton = placingButton;
+                targetLabel.text = placingButton ? "Placing: hand button" : "Placing: floating menus";
+            }
+        }
+
+        private static void ResetPlacement()
+        {
+            if (MenuManager.Instance.PlacingWristButton)
+            {
+                Settings.Instance.wristButtonOffset = Vector3.zero;
+                Settings.Instance.wristButtonAngle = Vector3.zero;
+            }
+            else
+            {
+                Settings.Instance.wristMenuOffset = Vector3.zero;
+                Settings.Instance.wristMenuAngle = Vector3.zero;
+            }
+
+            Settings.Instance.RequestSave();
+            Main.LogEntry("WristPanel", MenuManager.Instance.PlacingWristButton
+                ? "Hand button placement reset."
+                : "Floating menu placement reset.");
+        }
+
+        private static void SetNudge(int axis, float value)
+        {
+            Vector3 nudge = Nudge;
+            nudge[axis] = Mathf.Clamp(value, -MoveLimit, MoveLimit);
+
+            if (MenuManager.Instance.PlacingWristButton)
+            {
+                Settings.Instance.wristButtonOffset = nudge;
+            }
+            else
+            {
+                Settings.Instance.wristMenuOffset = nudge;
+            }
+            Settings.Instance.RequestSave();
+        }
+
+        private static void SetTilt(int axis, float value)
+        {
+            Vector3 tilt = Tilt;
+            tilt[axis] = Mathf.Repeat(value + 180f, 360f) - 180f;
+
+            if (MenuManager.Instance.PlacingWristButton)
+            {
+                Settings.Instance.wristButtonAngle = tilt;
+            }
+            else
+            {
+                Settings.Instance.wristMenuAngle = tilt;
+            }
+            Settings.Instance.RequestSave();
+        }
+
+        /// <summary>One number on the panel, and where to read it from.</summary>
+        private class Readout
+        {
+            public readonly Text Field;
+            public readonly Func<float> Read;
+            public readonly string Format;
+            public float Last = float.NaN;
+
+            public Readout(Text field, Func<float> read, string format)
+            {
+                Field = field;
+                Read = read;
+                Format = format;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ The menus and chat displays live on world-space panels. There are two kinds of p
 -- The **Displays** panel lists every display in the current locomotive, with a Move and a Size lock for each, and a Close button
 -- The **x** button in the top right corner of any display closes that display and forgets its saved slot
 -- Keys, placement distance and scale are set in the Unity Mod Manager menu, where the grab bars can also be turned off
-- **Wrist panel** (VR only) - a smaller copy of the menus attached to a controller, glance at it like a watch
--- Choose the hand, size, offset and rotation in the Unity Mod Manager menu; changes apply live
+- **Wrist panel** (VR only) - a small button on the back of your hand that opens into the full menus, glance at it like a watch
+-- It rides the same sticky pad the game uses for anything you carry, so it lies flat against the back of the hand whichever controllers you have
+-- It rests as a compact button, so it stays out of the way until you press it
+-- Opened, the menus unfold back down your forearm instead of sitting on top of your hand
+-- Press the back button on its Main panel to fold the menus back down to the button
+-- **Wrist Adjust** on any Main panel places it without leaving VR: three rows move it across the hand, along the arm and out from it, three more turn it, and each row has a fine and a coarse step either side of the number
+-- The button and the open menus are placed separately, and each remembers its own spot: press "Placing:" to switch between them. While you are placing the button it stays on show next to the menus so you can see where it is going
+-- In VR you can also just take hold of it: with the Wrist Adjust panel open, squeeze the grip on your free hand next to the panel to carry it, and let go where you want it. Where it lands is saved straight away
+-- Both start where they were measured to sit on the hand, so there is nothing to set up unless you want them elsewhere
+-- Choose the hand and the size in the Unity Mod Manager menu; changes apply live
 -- Its "Place Display" button is the VR way to summon the cab display without a keyboard
 
 - Every host shows the same panels and remembers which panel it last showed
@@ -71,12 +79,13 @@ The menus and chat displays live on world-space panels. There are two kinds of p
 -- Standard Messages - Enable/Disable your automatic Connect/Disconnect messages
 -- Command Messages - Enable/Disable the !info and !command ...commands
 -- Timed Messages - Enable/Disable the timed messages system
--- Displays - List the displays in this locomotive, lock each one's position or size, and close the ones you are done with
+-- Displays - List the displays in this locomotive, lock the position or size of each, and close the ones you are done with
+-- Wrist Adjust - Move and turn the wrist panel on your hand, or grab it and put it there by hand in VR
 -- Debug - Set debug level, several 'debug and testing' related buttons
 
 - Buttons can be interacted with in both VR and non-VR modes
 - Top left panel buttons will 'minimize' the displayed panel
-- Top right panel buttons return to the 'Main' panel (does nothing 'on' the Main panel), and close the display on cab displays
+- Top right panel buttons return to the 'Main' panel, and close the display on cab displays. From the Main panel, back does nothing on a cab display and folds the wrist panel away to its button
 - Each 'click' of the Notification duration slider in VR mode will advance approx 10%, then reset after max
 
 ### Twitch Authentication
@@ -167,6 +176,14 @@ Access advanced options by expanding the "Debug and Troubleshooting" section in 
 - [GitHub Repository](https://github.com/Nightwind416/Derail-Valley-Twitch-Chat-Mod)
 
 ## Version History
+
+### 3.4.2 (September 4, 2026)
+
+- The wrist panel now sits on the back of your hand instead of floating off the controller. It hangs off the game's own hand pad, the one your licenses and gadgets stick to, so it lands on the hand whichever controllers you use rather than wherever the controller pose happens to be
+- The VR wrist panel now starts as a small button rather than the full menus. Press it to open them, and press back on the Main panel to fold it away again
+- The hand button and the open menus are placed separately and each keeps its own spot, so the button can lie on the back of your hand while the menus stand up where you can read them
+- New Wrist Adjust panel, reachable from any Main panel, for placing them from inside VR: six stepped rows for moving and turning whichever one you are placing, and in VR you can simply take hold of it with your free hand and let go where you want it
+- Both start where they were measured to sit, so there should be nothing to adjust unless you want it elsewhere. The old wrist offset and rotation sliders have left the Unity Mod Manager menu, since the in-game panel does the job properly
 
 ### 3.4.0 (September 4, 2026)
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -78,11 +78,24 @@ namespace TwitchChat
         public string wristPanel = "Main";
         public bool wristPanelOnLeftHand = true;
         public float wristPanelScale = 0.6f;
-        public Vector3 wristPanelOffset = DefaultWristOffset;
-        public Vector3 wristPanelRotation = DefaultWristRotation;
 
-        public static readonly Vector3 DefaultWristOffset = new(0f, 0.04f, -0.10f);
-        public static readonly Vector3 DefaultWristRotation = new(90f, 0f, 0f);
+        /// <summary>
+        /// Where the open menus sit, measured from where the mod puts them on the back of the hand, in metres:
+        /// x across the menus, y along them, z out of the hand. Zero leaves them where the mod puts them.
+        /// </summary>
+        public Vector3 wristMenuOffset = Vector3.zero;
+
+        /// <summary>Extra turn in degrees on top of that, for players who want the menus at another angle.</summary>
+        public Vector3 wristMenuAngle = Vector3.zero;
+
+        /// <summary>
+        /// Where the button the menus fold down to sits, in the same terms. Kept apart from the menus, since the
+        /// button wants to lie on the back of the hand while the menus want to stand up where they can be read.
+        /// </summary>
+        public Vector3 wristButtonOffset = Vector3.zero;
+
+        /// <summary>Extra turn in degrees for the button, on top of where the mod puts it.</summary>
+        public Vector3 wristButtonAngle = Vector3.zero;
         
         // Standard Messages Settings
         public bool connectMessageEnabled = true;
@@ -446,16 +459,14 @@ namespace TwitchChat
                     }
                 GUILayout.EndHorizontal();
                 wristPanelScale = SliderRow("Wrist panel scale", wristPanelScale, 0.2f, 1.5f, "0.00");
-                wristPanelOffset.x = SliderRow("Wrist offset X (m)", wristPanelOffset.x, -0.3f, 0.3f, "0.000");
-                wristPanelOffset.y = SliderRow("Wrist offset Y (m)", wristPanelOffset.y, -0.3f, 0.3f, "0.000");
-                wristPanelOffset.z = SliderRow("Wrist offset Z (m)", wristPanelOffset.z, -0.3f, 0.3f, "0.000");
-                wristPanelRotation.x = SliderRow("Wrist rotation X (deg)", wristPanelRotation.x, -180f, 180f, "0");
-                wristPanelRotation.y = SliderRow("Wrist rotation Y (deg)", wristPanelRotation.y, -180f, 180f, "0");
-                wristPanelRotation.z = SliderRow("Wrist rotation Z (deg)", wristPanelRotation.z, -180f, 180f, "0");
+                GUILayout.Label("    The panel sits on the back of the hand by itself. To move it, use the in-game Wrist Adjust panel,");
+                GUILayout.Label("    which places the button and the open menus separately and can be reached from any Main panel.");
                 if (GUILayout.Button("Reset wrist panel to defaults", GUILayout.Width(200)))
                 {
-                    wristPanelOffset = DefaultWristOffset;
-                    wristPanelRotation = DefaultWristRotation;
+                    wristMenuOffset = Vector3.zero;
+                    wristMenuAngle = Vector3.zero;
+                    wristButtonOffset = Vector3.zero;
+                    wristButtonAngle = Vector3.zero;
                     wristPanelScale = 0.6f;
                 }
             GUILayout.EndVertical();

--- a/TwitchChat.csproj
+++ b/TwitchChat.csproj
@@ -9,7 +9,7 @@
 		<DerailValleyManagedAssets>D:\SteamLibrary\steamapps\common\Derail Valley\DerailValley_Data\Managed\</DerailValleyManagedAssets> <!-- Change to local game install path during build -->
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 		<DebugType>none</DebugType>
-		<ModVersion>3.4.0</ModVersion>
+		<ModVersion>3.4.2</ModVersion>
 		<ModAuthor>Nightwind416</ModAuthor>
 		<GameVersion>build 99</GameVersion>
 		<EntryMethod>TwitchChat.Main.Load</EntryMethod>

--- a/WristPanelGrab.cs
+++ b/WristPanelGrab.cs
@@ -1,0 +1,159 @@
+using System;
+using UnityEngine;
+using VRTK;
+
+namespace TwitchChat
+{
+    /// <summary>
+    /// Lets the wrist panel be taken in the free hand and put where the player wants it, while its adjust panel
+    /// is open. Where it lands is written straight back into the placement settings, so the numbers on that
+    /// panel and the panel itself always agree.
+    /// </summary>
+    /// <remarks>
+    /// Like the display grab bars this creates no collider and only reads controller state: a collider here
+    /// would be folded into the rigidbody of whatever the panel hangs off. The hand wearing the panel is
+    /// ignored, since it is always within reach of it and gripping is how that hand holds everything else.
+    /// </remarks>
+    public class WristPanelGrab : MonoBehaviour
+    {
+        /// <summary>How close a hand has to get before its grip picks the panel up, in metres.</summary>
+        private const float ReachDistance = 0.2f;
+
+        private const float ControllerSearchInterval = 2f;
+
+        private Transform? leftHand;
+        private Transform? rightHand;
+        private VRTK_ControllerEvents? leftEvents;
+        private VRTK_ControllerEvents? rightEvents;
+        private float nextControllerSearch;
+
+        private Transform? activeHand;
+        private VRTK_ControllerEvents? activeEvents;
+        private Vector3 holdOffsetPosition;
+        private Quaternion holdOffsetRotation;
+        private Action? placed;
+
+        /// <summary>True only while the panel is being placed, which is while its adjust panel is open.</summary>
+        public bool AdjustMode { get; set; }
+
+        /// <summary>Which hand is wearing the panel, so that hand's grip is left to do its normal job.</summary>
+        public bool WornOnLeft { get; set; }
+
+        /// <summary>What the reach is measured to: the menus themselves, rather than the point on the hand.</summary>
+        public Transform? Reference { get; set; }
+
+        /// <summary>True while a hand is carrying the panel, so its usual pose is left alone meanwhile.</summary>
+        public bool IsHeld => activeHand != null;
+
+        /// <summary>Gives the component somewhere to report a panel that has just been put down.</summary>
+        public void Initialize(Action onPlaced)
+        {
+            placed = onPlaced;
+        }
+
+        private void LateUpdate()
+        {
+            if (!AdjustMode || !VRManager.IsVREnabled())
+            {
+                Drop();
+                return;
+            }
+
+            FindControllers();
+
+            if (activeHand != null)
+            {
+                CarryOrDrop();
+                return;
+            }
+
+            TryPickUp();
+        }
+
+        private void TryPickUp()
+        {
+            Transform target = Reference != null ? Reference : transform;
+
+            for (int hand = 0; hand < 2; hand++)
+            {
+                bool isLeft = hand == 0;
+                if (isLeft == WornOnLeft)
+                {
+                    continue; // the hand the panel is on
+                }
+
+                Transform? handTransform = isLeft ? leftHand : rightHand;
+                VRTK_ControllerEvents? events = isLeft ? leftEvents : rightEvents;
+                if (handTransform == null || events == null || !events.gripPressed)
+                {
+                    continue;
+                }
+
+                if (Vector3.Distance(handTransform.position, target.position) > ReachDistance)
+                {
+                    continue;
+                }
+
+                activeHand = handTransform;
+                activeEvents = events;
+                holdOffsetPosition = Quaternion.Inverse(handTransform.rotation) * (transform.position - handTransform.position);
+                holdOffsetRotation = Quaternion.Inverse(handTransform.rotation) * transform.rotation;
+
+                Main.LogEntry("WristPanel", $"Wrist panel picked up by the {(isLeft ? "left" : "right")} hand for placing.");
+                return;
+            }
+        }
+
+        private void CarryOrDrop()
+        {
+            bool stillHeld = activeEvents != null
+                && activeHand != null
+                && activeHand.gameObject.activeInHierarchy
+                && activeEvents.gripPressed;
+
+            if (!stillHeld)
+            {
+                Drop();
+                return;
+            }
+
+            transform.SetPositionAndRotation(
+                activeHand!.position + (activeHand.rotation * holdOffsetPosition),
+                activeHand.rotation * holdOffsetRotation);
+        }
+
+        private void Drop()
+        {
+            if (activeHand == null)
+            {
+                return;
+            }
+
+            activeHand = null;
+            activeEvents = null;
+            placed?.Invoke();
+        }
+
+        private void FindControllers()
+        {
+            if (leftHand != null && rightHand != null)
+            {
+                return;
+            }
+            if (Time.unscaledTime < nextControllerSearch)
+            {
+                return;
+            }
+            nextControllerSearch = Time.unscaledTime + ControllerSearchInterval;
+
+            if (leftHand == null)
+            {
+                PanelGrabHandles.Resolve(VRTK_DeviceFinder.GetControllerLeftHand(false), VRTK_DeviceFinder.GetControllerLeftHand(true), ref leftHand, ref leftEvents);
+            }
+            if (rightHand == null)
+            {
+                PanelGrabHandles.Resolve(VRTK_DeviceFinder.GetControllerRightHand(false), VRTK_DeviceFinder.GetControllerRightHand(true), ref rightHand, ref rightEvents);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

The wrist panel hung off the raw VRTK controller transform, which is not where the hand is. Derail Valley fits the hand model to each controller type with its own offset and rotation — up to 18 cm and more than 100 degrees, per `config/ControllerAnchors.json` — so no fixed offset from the controller could line up with the back of the hand, and it was wrong differently on every headset. In game it hung off the fingertips, facing backwards.

## What changed

**Anchoring.** The panel now hangs off the game's own hand pad, the `[pipa]` object that licenses and gadgets stick to, found through `PipaUtils.PipaTransform` with a by-name fallback under the controller for the case where the game's cache is not filled yet. The pad is built at a tenth scale, so that is divided back out of both position and size. If no pad ever turns up, it falls back to the controller pose after a few tries rather than never appearing.

**Resting as a button.** The panel starts as a small button and opens into the full menus when pressed; back from the Main panel folds it away again. That back button previously did nothing.

**Two placements.** The button and the open menus are separate canvases with separately saved placements, since the button wants to lie on the back of the hand while the menus want to stand up where they can be read. Both default to poses measured by placing them by hand in VR. Those are stored against the pad rather than against the controller, so they should hold for any controller type, though they were only measured on a Quest 3.

**Placing them.** New Wrist Adjust panel, reachable from the Main panel on any host, so the wrist panel can be placed without leaving VR:

- Six stepped rows — across, along, out, and three turns — each with a fine and a coarse step either side of the live number. Stepped rather than sliders because the existing VR slider advances in tenths on touch and wraps at the end, and its readout is cast to `int`, which reads 0 for everything in metres.
- A Placing toggle switching between the menus and the button. While the button is being placed it stays on show next to the open menus so you can see where it is going.
- In VR either surface can be taken in the free hand: squeeze the grip next to it, and where it lands is converted straight back into that surface's settings, so the panel, the numbers and what is saved always agree. The hand wearing the panel is ignored, since its grip has a day job.

## Notes for review

- The four wrist placement settings are renamed (`wristMenuOffset` / `wristMenuAngle` / `wristButtonOffset` / `wristButtonAngle`). This is deliberate: the old saved values were adjustments measured against the old computed fit, and applying them on top of the new baked-in poses would double the offset. Renaming makes UMM drop them and use the new defaults.
- The six wrist sliders have left the Unity Mod Manager menu. Everything they did the in-game panel now does, for both surfaces rather than one, and in the headset where it is actually needed. Enable, hand, scale and a reset button stay.
- `PanelGrabHandles.Resolve` changed from private to internal so the wrist grab picks its controllers the same way, rather than duplicating that logic.
- No new colliders: like the display grab bars, the wrist grab works on hand proximity, so it cannot be folded into the rigidbody of whatever the panel hangs off.
- `ModVersion` bumped to 3.4.2 and the changelog given its own section.

## Testing

Tested in VR on a Quest 3: the panel attaches to the left hand pad, opens and folds, and both surfaces were placed by hand and came back where they were left. Not tested outside VR (the wrist panel is VR only), on other controller types, or with the pad missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
