### PR TITLE
Move colored announcements from the roadmap to the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - **Real-Time Chat Display**: View Twitch chat messages through in-game display panels (and popup notifications)
 - **Authentication You Can Audit**: OAuth handled directly between you and Twitch, asking for only the four permissions the mod actually uses, revocable from inside the game
 - **Message Logging**: Detailed chat logs for post-stream review
-- **Automated Messages**: Schedule periodic announcements to keep your chat informed
+- **Automated Messages**: Schedule up to five periodic announcements, each posted in the color you pick - normal, blue, green, orange, purple, or your channel accent
 - **Displays You Size Yourself**: Up to 5 panels per locomotive, each dragged to whatever size suits it
 - **Color Customization**: Ability to customize panel, section, and button coloring
 
@@ -19,8 +19,8 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - Message throttling and combining for busy chats
 - User list management (VIP, ignore, etc.)
 - Integration with "Remote Dispatch" mod
-- Colored announcement system for timed messages
 - Display panel scrolling in VR
+- Editing timed message text and intervals from the in-game panel, instead of the Unity Mod Manager menu or Settings.xml
 
 ## Installation
 


### PR DESCRIPTION
## What changed

Two lines in the README, following a pass over the open issues:

- **Automated Messages** now says what it actually does - up to five periodic announcements, each in a color you pick.
- **Colored announcement system for timed messages** leaves the "Upcoming Features (In Development)" list, since it has been shipping for a while.
- In its place on the roadmap: editing timed message text and intervals from the in-game panel, which genuinely is not built yet.

## Why

Reviewing the seven open issues turned up three that no longer reflected the code, and the README had drifted the same way.

The colored timed message system is complete. Each of the five timed messages carries its own color, cycled through `Normal / Blue / Green / Orange / Purple / Primary` in `Settings.cs`. `Normal` sends as an ordinary chat message; anything else goes out as a channel announcement in that color via `TwitchEventHandler.SendAnnouncement`, dispatched from `AutomatedMessages`. `moderator:manage:announcements` is one of the four scopes the mod requests, asked for specifically so this works.

What is *not* built is editing those messages from the in-game panel - `PanelMenus/TimedMessages.cs` still tells you to use the Unity Mod Manager menu or Settings.xml. That is the part worth keeping on the roadmap, so it takes the old entry's place.

## Issues closed alongside this

- #11 - colored announcements, closed as complete (this change)
- #13 - choosing which licenses to replace, closed as obsolete: the license paper host was removed in 8213a10, so there are no licenses to choose between
- #7 - alternate version using the custom item mod, closed as obsolete for the same reason, with a note to the reporter that their concern was resolved by a different route

## For the reviewer

Documentation only - no code changes, nothing to test in game.

Note that #8 (subscriber/follower alerts) is still open but now sits against a deliberate promise: the in-game consent screen lists "See your subscribers, followers or revenue" under things the mod cannot do (`OAuthManager.ScopeExclusions`). Building it would mean adding `channel:read:subscriptions` and `moderator:read:followers` and rewriting that exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)