### PR TITLE
Open the displays to panels from other mods, with three to start (v3.5.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+	<!--
+		Shared by every project in the solution so the game path is written down once. Change these two
+		to match the local game install before building.
+	-->
+	<PropertyGroup>
+		<DerailValleyManagedAssets>D:\SteamLibrary\steamapps\common\Derail Valley\DerailValley_Data\Managed\</DerailValleyManagedAssets>
+		<ModOutputPath>D:\SteamLibrary\steamapps\common\Derail Valley\Mods\TwitchChat</ModOutputPath>
+	</PropertyGroup>
+</Project>

--- a/Main.cs
+++ b/Main.cs
@@ -233,7 +233,7 @@ namespace TwitchChat
                 if (Settings.Instance.debugLevel == DebugLevel.Off)
                     return;
                 if (Settings.Instance.debugLevel == DebugLevel.Minimal &&
-                    !MinimalDebug.Contains(source))
+                    !MinimalDebug.Contains(source) && !IsPluginSource(source))
                     return;
                 if (Settings.Instance.debugLevel == DebugLevel.Reduced &&
                     ReducedDebug.Contains(source))
@@ -269,6 +269,26 @@ namespace TwitchChat
                     return;
                 }
             }
+        }
+
+        /// <summary>
+        /// Whether a log source belongs to the plugin machinery, which is always worth logging.
+        /// </summary>
+        /// <remarks>
+        /// A plugin reads another mod's internals, so it is the part of this mod most likely to be broken
+        /// by something outside it, and its failures are the ones a player will be reporting. Filtering
+        /// those out at the default debug level left a player looking at a panel saying it had stopped
+        /// and a log with nothing in it at all.
+        /// <para>
+        /// A prefix rather than a list because a plugin's own log lines are tagged with its id, so the
+        /// full set of sources is not known here.
+        /// </para>
+        /// </remarks>
+        private static bool IsPluginSource(string source)
+        {
+            return source.StartsWith("Plugin", StringComparison.Ordinal)
+                || source.StartsWith("PanelRegistry", StringComparison.Ordinal)
+                || source.StartsWith("PanelDescriptor", StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/Main.cs
+++ b/Main.cs
@@ -17,7 +17,6 @@ namespace TwitchChat
     /// </summary>
     public static class Main
     {
-        public static bool _dispatcherModDetected;
         public static UnityModManager.ModEntry ModEntry { get; private set; } = null!;
         public static string settingsFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Mods", "TwitchChat", "Settings.xml");
         public static string debugLog = string.Empty;
@@ -55,20 +54,6 @@ namespace TwitchChat
                 UnityEngine.Object.DontDestroyOnLoad(dispatcherObject);
                 ModEntry.Logger.Log("[Load] UnityMainThreadDispatcher initialized.");
                 LogEntry(methodName, "UnityMainThreadDispatcher initialized successfully.");
-
-                // Check for RemoteDispatch Mod
-                var remoteDispatchMod = UnityModManager.modEntries.FirstOrDefault(mod => mod.Info.Id == "RemoteDispatch");
-                if (remoteDispatchMod != null)
-                {
-                    ModEntry.Logger.Log("[Load] RemoteDispatch Mod detected.");
-                    LogEntry(methodName, "RemoteDispatch Mod detected and verified.");
-                    _dispatcherModDetected = true;
-                }
-                else
-                {
-                    ModEntry.Logger.Log("[Load] RemoteDispatch Mod not detected.");
-                    LogEntry(methodName, "RemoteDispatch Mod not found - mod will operate in standalone mode.");
-                }
 
                 // Panels, the mod's own and any contributed by plugins, before the first display is built
                 Plugins.PluginLoader.LoadAll(modEntry.Path);

--- a/Main.cs
+++ b/Main.cs
@@ -36,6 +36,11 @@ namespace TwitchChat
 
             try
             {
+                // Before anything else: the assemblies shipped beside this one, TwitchChat.Api among them,
+                // are not on the runtime's usual search path. Nothing above this line may touch a type from
+                // one of them, which is why this is the first statement in the method.
+                Plugins.AssemblyResolver.Install(modEntry.Path);
+
                 // Settings first, so the logger knows the configured debug level
                 Settings.Instance = UnityModManager.ModSettings.Load<Settings>(modEntry) ?? new Settings();
                 OAuthTokenManager.InitialisePhaseFromSettings();
@@ -64,6 +69,10 @@ namespace TwitchChat
                     ModEntry.Logger.Log("[Load] RemoteDispatch Mod not detected.");
                     LogEntry(methodName, "RemoteDispatch Mod not found - mod will operate in standalone mode.");
                 }
+
+                // Panels, the mod's own and any contributed by plugins, before the first display is built
+                Plugins.PluginLoader.LoadAll(modEntry.Path);
+                LogEntry(methodName, "Panel registry populated.");
 
                 // Register the mod's toggle and update methods
                 ModEntry.OnToggle = OnToggle;

--- a/Main.cs
+++ b/Main.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using UnityEngine;
 using UnityModManagerNet;
 
@@ -246,28 +245,20 @@ namespace TwitchChat
                 return;
             }
 
-            int retryCount = 3;
-            int delay = 1000; // 1 second
-
-            for (int i = 0; i < retryCount; i++)
+            // No retrying, and above all no sleeping. This is called from the game loop, and a log file
+            // momentarily locked - by a text editor, or by someone reading it while playing - used to
+            // stop the game dead for up to three seconds. A missed line is the cheaper loss by far:
+            // the manager's own log still gets it.
+            try
             {
-                try
-                {
-                    using StreamWriter writer = new(selected_log, true);
-                    string logMessage = selected_log == debugLog ? $"[{source}] {message}" : message;
-                    writer.WriteLine($"{DateTime.Now:HH:mm}: {logMessage}");
-                    return;
-                }
-                catch (IOException ex) when (i < retryCount - 1)
-                {
-                    ModEntry.Logger.Log($"[{source}] Failed to write to log file: {selected_log}. Exception: {ex.Message}. Retrying in {delay}ms...");
-                    Thread.Sleep(delay);
-                }
-                catch (Exception ex)
-                {
-                    ModEntry.Logger.Log($"[{source}] Failed to write to log file: {selected_log}. Exception: {ex.Message}");
-                    return;
-                }
+                using StreamWriter writer = new(selected_log, true);
+                string logMessage = selected_log == debugLog ? $"[{source}] {message}" : message;
+                writer.WriteLine($"{DateTime.Now:HH:mm}: {logMessage}");
+            }
+            catch (Exception ex)
+            {
+                ModEntry.Logger.Log($"[{source}] {message}");
+                ModEntry.Logger.Log($"[{source}] Could not write to {selected_log}: {ex.Message}");
             }
         }
 

--- a/MenuManager.cs
+++ b/MenuManager.cs
@@ -126,24 +126,16 @@ namespace TwitchChat
         }
 
         /// <summary>
-        /// Defines the types of panels available in the mod interface.
+        /// Panel names written into settings before the sized chat displays were merged into one. A
+        /// display saved under one of these still opens, on the single Chat panel that replaced them.
         /// </summary>
-        private enum PanelType
+        private static readonly Dictionary<string, string> RenamedPanels = new()
         {
-            Main,
-            Authentication,
-            Status,
-            Notifications,
-            Chat,
-            StandardMessages,
-            CommandMessages,
-            TimedMessages,
-            Config1,
-            Config2,
-            Displays,
-            WristAdjust,
-            Debug
-        }
+            ["Large Display"] = "Chat",
+            ["Medium Display"] = "Chat",
+            ["Wide Display"] = "Chat",
+            ["Small Display"] = "Chat"
+        };
 
         /// <summary>
         /// Gets the singleton instance of the MenuManager.
@@ -165,6 +157,10 @@ namespace TwitchChat
 
         private void Awake()
         {
+            // Normally already done during Load; harmless to repeat, and it means a display can still be
+            // built if the manager is reached before the plugins have been looked for
+            Plugins.PanelRegistry.RegisterBuiltIns();
+
             CreateTemplateCanvas();
             PlayerManager.CarChanged += OnPlayerCarChanged;
         }
@@ -223,20 +219,12 @@ namespace TwitchChat
         /// Creates template instances of all panel types.
         /// </summary>
         /// <param name="parent">Parent transform to attach panel templates to.</param>
-        private void CreatePanelTemplates(Transform parent)
+        private static void CreatePanelTemplates(Transform parent)
         {
-            _ = new MainPanel(parent, null);
-            _ = new StatusPanel(parent);
-            _ = new NotificationsPanel(parent);
-            _ = new ChatPanel(parent);
-            _ = new StandardMessagesPanel(parent);
-            _ = new CommandMessagesPanel(parent);
-            _ = new TimedMessagesPanel(parent);
-            _ = new Config1Panel(parent);
-            _ = new Config2Panel(parent);
-            _ = new DisplaysPanel(parent);
-            _ = new WristAdjustPanel(parent);
-            _ = new DebugPanel(parent);
+            foreach (Plugins.PanelDescriptor descriptor in Plugins.PanelRegistry.Available)
+            {
+                _ = descriptor.Create(parent, null);
+            }
 
             // Hide all template panels
             foreach (Transform child in parent)
@@ -592,7 +580,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.DisplaysPanel?.Rebuild(cabDisplays, host);
+                host.Get<DisplaysPanel>()?.Rebuild(cabDisplays, host);
             }
         }
 
@@ -1088,15 +1076,19 @@ namespace TwitchChat
         // ------------------------------------------------------------------
 
         /// <summary>
-        /// Updates values displayed on active panels.
+        /// Refreshes whatever the host is currently showing. Only the visible panel is asked: the rest are
+        /// hidden behind it, and a plugin panel reading another mod's state has no business doing so
+        /// thirteen times over for panels nobody is looking at.
         /// </summary>
-        private void UpdatePanelValues(PanelHost host)
+        private static void UpdatePanelValues(PanelHost host)
         {
-            host.AuthenticationPanel?.UpdateAuthenticationPanelValues();
-            host.StatusPanel?.UpdateStatusPanelValues();
-            host.StandardMessagesPanel?.UpdateStandardMessagesPanelValues();
-            host.CommandMessagesPanel?.UpdateCommandMessagesPanelValues();
-            host.WristAdjustPanel?.UpdateValues();
+            foreach (PanelConstructor.BasePanel panel in host.Panels)
+            {
+                if (panel.IsVisible)
+                {
+                    panel.Tick(Time.deltaTime);
+                }
+            }
         }
 
         public void OnPanelButtonClicked(string panelName, PanelHost host)
@@ -1119,37 +1111,28 @@ namespace TwitchChat
 
             Transform menuPanel = host.MenuCanvas.transform.Find("MenuPanel");
 
-            // Create and wire up all panels from the templates
-            host.MainPanel = new MainPanel(menuPanel, host);
-            host.AuthenticationPanel = new AuthenticationPanel(menuPanel);
-            host.StatusPanel = new StatusPanel(menuPanel);
-            host.NotificationsPanel = new NotificationsPanel(menuPanel);
-            host.ChatPanel = new ChatPanel(menuPanel);
-            host.StandardMessagesPanel = new StandardMessagesPanel(menuPanel);
-            host.CommandMessagesPanel = new CommandMessagesPanel(menuPanel);
-            host.TimedMessagesPanel = new TimedMessagesPanel(menuPanel);
-            host.Config1Panel = new Config1Panel(menuPanel);
-            host.Config2Panel = new Config2Panel(menuPanel);
-            host.DisplaysPanel = new DisplaysPanel(menuPanel);
-            host.WristAdjustPanel = new WristAdjustPanel(menuPanel);
-            host.DebugPanel = new DebugPanel(menuPanel);
+            // Build every panel the registry currently offers, the mod's own and any from plugins alike.
+            // Back on any of them returns to the main menu; back on the main menu is the one exception,
+            // wired up below by whichever kind of host this is.
+            host.ClearPanels();
+            foreach (Plugins.PanelDescriptor descriptor in Plugins.PanelRegistry.Available)
+            {
+                PanelConstructor.BasePanel? panel = descriptor.Create(menuPanel, host);
+                if (panel == null)
+                {
+                    continue;
+                }
+
+                host.AddPanel(descriptor.Id, panel);
+
+                if (descriptor.Id != "Main")
+                {
+                    panel.OnBackButtonClicked += () => ShowPanel("Main", host);
+                }
+            }
 
             // Explicitly hide all panels immediately after creation
             HideAllPanels(host);
-
-            // Wire up back button events
-            host.AuthenticationPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.StatusPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.NotificationsPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.ChatPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.StandardMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.CommandMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.TimedMessagesPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.Config1Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.Config2Panel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.DisplaysPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.WristAdjustPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
-            host.DebugPanel.OnBackButtonClicked += () => ShowPanel("Main", host);
 
             // Cab displays are the hosts the player moves and resizes, so they are the ones that get grab bars
             if (host is CabDisplayHost display && menuPanel != null)
@@ -1163,7 +1146,12 @@ namespace TwitchChat
             if (host is WristPanelHost wrist)
             {
                 CreateWristButton(wrist);
-                host.MainPanel.OnBackButtonClicked += () => SetWristExpanded(false);
+
+                PanelConstructor.BasePanel? mainPanel = host.GetPanel("Main");
+                if (mainPanel != null)
+                {
+                    mainPanel.OnBackButtonClicked += () => SetWristExpanded(false);
+                }
 
                 wristGrab = host.MenuCanvas.AddComponent<WristPanelGrab>();
                 wristGrab.Initialize(() => OnWristSurfacePlaced(false));
@@ -1184,19 +1172,10 @@ namespace TwitchChat
 
         private static void HideAllPanels(PanelHost host)
         {
-            host.MainPanel?.Hide();
-            host.AuthenticationPanel?.Hide();
-            host.StatusPanel?.Hide();
-            host.NotificationsPanel?.Hide();
-            host.ChatPanel?.Hide();
-            host.StandardMessagesPanel?.Hide();
-            host.CommandMessagesPanel?.Hide();
-            host.TimedMessagesPanel?.Hide();
-            host.Config1Panel?.Hide();
-            host.Config2Panel?.Hide();
-            host.DisplaysPanel?.Hide();
-            host.WristAdjustPanel?.Hide();
-            host.DebugPanel?.Hide();
+            foreach (PanelConstructor.BasePanel panel in host.Panels)
+            {
+                panel.Hide();
+            }
         }
 
         private void ShowPanel(string panelName, PanelHost host)
@@ -1210,28 +1189,7 @@ namespace TwitchChat
 
             HideAllPanels(host);
 
-            PanelType panelType = panelName switch
-            {
-                "Main" => PanelType.Main,
-                "Authentication" => PanelType.Authentication,
-                "Status" => PanelType.Status,
-                "Notifications" => PanelType.Notifications,
-                "Chat" => PanelType.Chat,
-
-                // Settings written before the sized display panels were merged into one
-                "Large Display" or "Medium Display" or "Wide Display" or "Small Display" => PanelType.Chat,
-
-                "Standard Messages" => PanelType.StandardMessages,
-                "Command Messages" => PanelType.CommandMessages,
-                "Timed Messages" => PanelType.TimedMessages,
-                "Config1" => PanelType.Config1,
-                "Config2" => PanelType.Config2,
-                "Displays" => PanelType.Displays,
-                "Wrist Adjust" => PanelType.WristAdjust,
-                "Debug" => PanelType.Debug,
-                _ => PanelType.Main
-            };
-
+            string panelId = ResolvePanelId(panelName, host);
 
             // Panels have no size of their own: a display keeps whatever size it has been dragged to, whichever
             // panel it shows. A display that has never been sized starts at the default.
@@ -1252,59 +1210,44 @@ namespace TwitchChat
                 }
             }
 
-            if (panelType == PanelType.Displays)
+            // The two panels that list something the player has changed elsewhere are rebuilt on the way in
+            if (panelId == "Displays")
             {
-                host.DisplaysPanel?.Rebuild(cabDisplays, host);
+                host.Get<DisplaysPanel>()?.Rebuild(cabDisplays, host);
+            }
+            else if (panelId == "Mods")
+            {
+                host.Get<ModsPanel>()?.Rebuild();
             }
 
-            // Show the selected panel
-            switch (panelType)
-            {
-                case PanelType.Main:
-                    host.MainPanel?.Show();
-                    break;
-                case PanelType.Authentication:
-                    host.AuthenticationPanel?.Show();
-                    break;
-                case PanelType.Status:
-                    host.StatusPanel?.Show();
-                    break;
-                case PanelType.Notifications:
-                    host.NotificationsPanel?.Show();
-                    break;
-                case PanelType.Chat:
-                    host.ChatPanel?.Show();
-                    break;
-                case PanelType.StandardMessages:
-                    host.StandardMessagesPanel?.Show();
-                    break;
-                case PanelType.CommandMessages:
-                    host.CommandMessagesPanel?.Show();
-                    break;
-                case PanelType.TimedMessages:
-                    host.TimedMessagesPanel?.Show();
-                    break;
-                case PanelType.Config1:
-                    host.Config1Panel?.Show();
-                    break;
-                case PanelType.Config2:
-                    host.Config2Panel?.Show();
-                    break;
-                case PanelType.Displays:
-                    host.DisplaysPanel?.Show();
-                    break;
-                case PanelType.WristAdjust:
-                    host.WristAdjustPanel?.Show();
-                    break;
-                case PanelType.Debug:
-                    host.DebugPanel?.Show();
-                    break;
-            }
+            host.GetPanel(panelId)?.Show();
 
-            // Remember the active panel for this host, under its current name so the legacy sized-display
-            // names are not written back out again
-            host.ActivePanel = panelType == PanelType.Chat ? "Chat" : panelName;
+            // Remember the active panel for this host, under the id it resolved to, so a name that has
+            // since been renamed or removed is not written straight back out again
+            host.ActivePanel = panelId;
             Settings.Instance.RequestSave();
+        }
+
+        /// <summary>
+        /// Works out which panel a saved or clicked name means. A name that has been renamed since it was
+        /// saved is followed to its replacement, and one this host has no panel for - a plugin that has
+        /// been uninstalled, or switched off - falls back to the main menu rather than leaving the display
+        /// blank.
+        /// </summary>
+        private static string ResolvePanelId(string panelName, PanelHost host)
+        {
+            if (RenamedPanels.TryGetValue(panelName, out string? renamed))
+            {
+                panelName = renamed;
+            }
+
+            if (host.GetPanel(panelName) != null)
+            {
+                return panelName;
+            }
+
+            Main.LogEntry("ShowPanel", $"Host {host.Name} has no panel called '{panelName}'; showing Main instead.");
+            return "Main";
         }
 
         /// <summary>
@@ -1338,7 +1281,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.NotificationsPanel?.UpdateNotificationsEnabled(value);
+                host.Get<NotificationsPanel>()?.UpdateNotificationsEnabled(value);
             }
         }
 
@@ -1346,7 +1289,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.NotificationsPanel?.UpdateNotificationDuration(value);
+                host.Get<NotificationsPanel>()?.UpdateNotificationDuration(value);
             }
         }
 
@@ -1354,7 +1297,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.DebugPanel?.UpdateProcessOwn(value);
+                host.Get<DebugPanel>()?.UpdateProcessOwn(value);
             }
         }
 
@@ -1362,7 +1305,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.DebugPanel?.UpdateProcessDuplicates(value);
+                host.Get<DebugPanel>()?.UpdateProcessDuplicates(value);
             }
         }
 
@@ -1370,7 +1313,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.StandardMessagesPanel?.UpdateConnectMessageEnabled(value);
+                host.Get<StandardMessagesPanel>()?.UpdateConnectMessageEnabled(value);
             }
         }
 
@@ -1378,7 +1321,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.StandardMessagesPanel?.UpdateDisconnectMessageEnabled(value);
+                host.Get<StandardMessagesPanel>()?.UpdateDisconnectMessageEnabled(value);
             }
         }
 
@@ -1386,7 +1329,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.CommandMessagesPanel?.UpdateCommandsMessageEnabled(value);
+                host.Get<CommandMessagesPanel>()?.UpdateCommandsMessageEnabled(value);
             }
         }
 
@@ -1394,7 +1337,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.CommandMessagesPanel?.UpdateInfoMessageEnabled(value);
+                host.Get<CommandMessagesPanel>()?.UpdateInfoMessageEnabled(value);
             }
         }
 
@@ -1402,7 +1345,7 @@ namespace TwitchChat
         {
             foreach (PanelHost host in AllHosts)
             {
-                host.TimedMessagesPanel?.UpdateTimedMessagesEnabled(value);
+                host.Get<TimedMessagesPanel>()?.UpdateTimedMessagesEnabled(value);
             }
         }
 

--- a/PanelConstructor/BasePanel.cs
+++ b/PanelConstructor/BasePanel.cs
@@ -31,6 +31,13 @@ namespace TwitchChat.PanelConstructor
         protected bool showMinimizeButton = true;
 
         /// <summary>
+        /// What the title row reads. Panels that are a class of their own leave this null and are named
+        /// after their type; panels built for someone else's content, where one class serves many names,
+        /// pass their own.
+        /// </summary>
+        private readonly string? titleOverride;
+
+        /// <summary>
         /// Closes the display this panel is on. Created hidden and only revealed for hosts that can be
         /// closed, which is the cab displays; the wrist panel never shows one.
         /// </summary>
@@ -50,11 +57,55 @@ namespace TwitchChat.PanelConstructor
             }
         }
 
-        public virtual void Show() => panelObject.SetActive(true);
-        public virtual void Hide() => panelObject.SetActive(false);
+        /// <summary>Whether this panel is the one its display is currently showing.</summary>
+        public bool IsVisible => panelObject != null && panelObject.activeSelf;
 
-        protected BasePanel(Transform parent)
+        public virtual void Show()
         {
+            bool wasVisible = IsVisible;
+            panelObject.SetActive(true);
+
+            if (!wasVisible)
+            {
+                OnShown();
+            }
+        }
+
+        public virtual void Hide()
+        {
+            bool wasVisible = IsVisible;
+            panelObject.SetActive(false);
+
+            if (wasVisible)
+            {
+                OnHidden();
+            }
+        }
+
+        /// <summary>Called when the panel becomes the one on show, but not again while it stays there.</summary>
+        protected virtual void OnShown() { }
+
+        /// <summary>Called when the panel stops being the one on show.</summary>
+        protected virtual void OnHidden() { }
+
+        /// <summary>
+        /// Called once a frame while the panel is the one on show, to refresh whatever it is displaying.
+        /// </summary>
+        /// <param name="deltaTime">Seconds since the last call.</param>
+        public virtual void Tick(float deltaTime) { }
+
+        /// <summary>
+        /// Called when the display this panel is on has been dragged to a new size, in canvas units.
+        /// Panels anchored to their display need do nothing; those that lay themselves out by hand, or
+        /// draw into a texture, want to know.
+        /// </summary>
+        public virtual void OnResize(Vector2 size) { }
+
+        /// <param name="parent">Parent transform to attach the panel to.</param>
+        /// <param name="title">Title row text, or null to name the panel after its type.</param>
+        protected BasePanel(Transform parent, string? title = null)
+        {
+            titleOverride = title;
             CreateBasePanel(parent);
             // Get references from the scrollable area when created
             if (scrollableArea != null)
@@ -75,7 +126,7 @@ namespace TwitchChat.PanelConstructor
         /// <param name="parent">Parent transform to attach the panel to</param>
         protected virtual void CreateBasePanel(Transform parent)
         {
-            panelObject = new GameObject(GetType().Name);
+            panelObject = new GameObject(titleOverride == null ? GetType().Name : $"{titleOverride}Panel");
             panelObject.transform.SetParent(parent, false);
             
             Image panelImage = panelObject.AddComponent<Image>();
@@ -90,7 +141,7 @@ namespace TwitchChat.PanelConstructor
             rectTransform.anchoredPosition = Vector2.zero;
 
             // Create title using Title factory
-            Title.Create(panelObject.transform, GetType().Name.Replace("Panel", ""), 18);
+            Title.Create(panelObject.transform, titleOverride ?? GetType().Name.Replace("Panel", ""), 18);
 
             // Create close button, in the top right corner with the back button beside it
             closeButton = Button.Create(panelObject.transform, " x ", 0, 0, Color.white, () => closeAction?.Invoke());

--- a/PanelConstructor/BasePanel.cs
+++ b/PanelConstructor/BasePanel.cs
@@ -57,12 +57,17 @@ namespace TwitchChat.PanelConstructor
             }
         }
 
-        /// <summary>Whether this panel is the one its display is currently showing.</summary>
-        public bool IsVisible => panelObject != null && panelObject.activeSelf;
+        /// <summary>
+        /// Whether this panel is the one its display is currently showing. Tracked rather than read back
+        /// off the object, so that hiding every panel when a display is built - which happens before any
+        /// of them has been shown - does not tell them all they have just been hidden.
+        /// </summary>
+        public bool IsVisible { get; private set; }
 
         public virtual void Show()
         {
             bool wasVisible = IsVisible;
+            IsVisible = true;
             panelObject.SetActive(true);
 
             if (!wasVisible)
@@ -74,6 +79,7 @@ namespace TwitchChat.PanelConstructor
         public virtual void Hide()
         {
             bool wasVisible = IsVisible;
+            IsVisible = false;
             panelObject.SetActive(false);
 
             if (wasVisible)

--- a/PanelConstructor/ValueBar.cs
+++ b/PanelConstructor/ValueBar.cs
@@ -1,0 +1,139 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.PanelConstructor
+{
+    /// <summary>
+    /// Factory class for creating labelled bars that show a fraction of something, such as a throttle or
+    /// brake position. Unlike <see cref="HorizontalBar"/>, which is a plain separator rule, this is a
+    /// readout: a caption on the left, a track that fills from the left, and a value on the right.
+    /// </summary>
+    public static class ValueBar
+    {
+        /// <summary>How much of the row's width the caption takes, leaving the rest for the track.</summary>
+        private const float LabelWidth = 70f;
+
+        /// <summary>How much of the row's width the value on the right takes.</summary>
+        private const float ValueWidth = 44f;
+
+        private const int RowHeight = 16;
+
+        /// <summary>
+        /// Creates a labelled bar, empty to begin with. Set its value with <see cref="SetValue"/>.
+        /// </summary>
+        /// <param name="parent">Parent transform to attach the bar to</param>
+        /// <param name="label">Caption shown to the left of the track</param>
+        /// <param name="yPosition">Y position relative to parent</param>
+        /// <param name="fillColor">Optional colour for the filled part of the track</param>
+        /// <returns>Created GameObject, to be passed back to <see cref="SetValue"/></returns>
+        public static GameObject Create(Transform parent, string label, int yPosition, Color? fillColor = null)
+        {
+            GameObject row = new($"{label}ValueBar");
+            row.transform.SetParent(parent, false);
+
+            RectTransform rowRect = row.AddComponent<RectTransform>();
+            rowRect.anchorMin = new Vector2(0, 1);
+            rowRect.anchorMax = new Vector2(1, 1);
+            rowRect.pivot = new Vector2(0.5f, 1);
+            rowRect.offsetMin = new Vector2(10, 0);
+            rowRect.offsetMax = new Vector2(-10, 0);
+            rowRect.sizeDelta = new Vector2(rowRect.sizeDelta.x, RowHeight);
+            rowRect.anchoredPosition = new Vector2(0, -yPosition);
+
+            Text caption = NewText(row.transform, "Caption", label, TextAnchor.MiddleLeft, Color.white);
+            RectTransform captionRect = caption.rectTransform;
+            captionRect.anchorMin = new Vector2(0, 0);
+            captionRect.anchorMax = new Vector2(0, 1);
+            captionRect.pivot = new Vector2(0, 0.5f);
+            captionRect.sizeDelta = new Vector2(LabelWidth, 0);
+            captionRect.anchoredPosition = Vector2.zero;
+
+            // The track spans whatever is left between the caption and the value
+            GameObject track = new("Track");
+            track.transform.SetParent(row.transform, false);
+            track.AddComponent<Image>().color = new Color(0f, 0f, 0f, 0.5f);
+
+            RectTransform trackRect = track.GetComponent<RectTransform>();
+            trackRect.anchorMin = new Vector2(0, 0);
+            trackRect.anchorMax = new Vector2(1, 1);
+            trackRect.pivot = new Vector2(0, 0.5f);
+            trackRect.offsetMin = new Vector2(LabelWidth, 3);
+            trackRect.offsetMax = new Vector2(-ValueWidth, -3);
+
+            GameObject fill = new("Fill");
+            fill.transform.SetParent(track.transform, false);
+            fill.AddComponent<Image>().color = fillColor ?? new Color(0.2f, 0.6f, 1f, 0.9f);
+
+            RectTransform fillRect = fill.GetComponent<RectTransform>();
+            fillRect.anchorMin = new Vector2(0, 0);
+            fillRect.anchorMax = new Vector2(0, 1);
+            fillRect.pivot = new Vector2(0, 0.5f);
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            Text value = NewText(row.transform, "Value", "0%", TextAnchor.MiddleRight, Color.white);
+            RectTransform valueRect = value.rectTransform;
+            valueRect.anchorMin = new Vector2(1, 0);
+            valueRect.anchorMax = new Vector2(1, 1);
+            valueRect.pivot = new Vector2(1, 0.5f);
+            valueRect.sizeDelta = new Vector2(ValueWidth, 0);
+            valueRect.anchoredPosition = Vector2.zero;
+
+            SetValue(row, 0f);
+            return row;
+        }
+
+        /// <summary>
+        /// Updates a bar made by <see cref="Create"/>. Passing something that is not one is ignored, so a
+        /// caller need not guard against a bar that failed to build.
+        /// </summary>
+        /// <param name="bar">The object returned by <see cref="Create"/></param>
+        /// <param name="fraction">How full the bar is, from 0 to 1; values outside that are clamped</param>
+        /// <param name="valueText">Text shown on the right, or null for a percentage</param>
+        public static void SetValue(GameObject? bar, float fraction, string? valueText = null)
+        {
+            if (bar == null)
+            {
+                return;
+            }
+
+            fraction = Mathf.Clamp01(float.IsNaN(fraction) ? 0f : fraction);
+
+            Transform? track = bar.transform.Find("Track");
+            Transform? fill = track?.Find("Fill");
+            if (fill != null)
+            {
+                // The fill is anchored to the left of the track, so its width is the whole story
+                RectTransform fillRect = (RectTransform)fill;
+                fillRect.anchorMax = new Vector2(fraction, 1);
+                fillRect.offsetMin = Vector2.zero;
+                fillRect.offsetMax = Vector2.zero;
+            }
+
+            Transform? value = bar.transform.Find("Value");
+            Text? valueLabel = value != null ? value.GetComponent<Text>() : null;
+            if (valueLabel != null)
+            {
+                valueLabel.text = valueText ?? $"{Mathf.RoundToInt(fraction * 100f)}%";
+            }
+        }
+
+        private static Text NewText(Transform parent, string name, string text, TextAnchor alignment, Color color)
+        {
+            GameObject obj = new(name);
+            obj.transform.SetParent(parent, false);
+
+            Text component = obj.AddComponent<Text>();
+            component.text = text;
+            component.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            component.fontSize = 12;
+            component.alignment = alignment;
+            component.color = color;
+            component.raycastTarget = false;
+            component.horizontalOverflow = HorizontalWrapMode.Overflow;
+            component.verticalOverflow = VerticalWrapMode.Overflow;
+
+            return component;
+        }
+    }
+}

--- a/PanelHost.cs
+++ b/PanelHost.cs
@@ -1,36 +1,27 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using TwitchChat.PanelConstructor;
 using TwitchChat.PanelDisplays;
-using TwitchChat.PanelMenus;
 using UnityEngine;
 
 namespace TwitchChat
 {
     /// <summary>
     /// A surface that carries the mod's full panel stack: one world-space canvas plus an instance of
-    /// every menu and display panel. Concrete hosts decide where the canvas lives (the locomotive cab
+    /// every panel the registry offers. Concrete hosts decide where the canvas lives (the locomotive cab
     /// or the player's wrist) and where the active panel choice is persisted.
     /// </summary>
+    /// <remarks>
+    /// A host holds its panels by id rather than as a property each, so a panel contributed by a plugin
+    /// rides along with the mod's own without anything here knowing about it.
+    /// </remarks>
     public abstract class PanelHost
     {
+        private readonly Dictionary<string, BasePanel> panels = new();
+
         public string Name { get; }
         public GameObject? MenuCanvas { get; set; }
-
-        // Panel Menus
-        public MainPanel? MainPanel { get; set; }
-        public AuthenticationPanel? AuthenticationPanel { get; set; }
-        public StatusPanel? StatusPanel { get; set; }
-        public NotificationsPanel? NotificationsPanel { get; set; }
-        public StandardMessagesPanel? StandardMessagesPanel { get; set; }
-        public CommandMessagesPanel? CommandMessagesPanel { get; set; }
-        public TimedMessagesPanel? TimedMessagesPanel { get; set; }
-        public Config1Panel? Config1Panel { get; set; }
-        public Config2Panel? Config2Panel { get; set; }
-        public DisplaysPanel? DisplaysPanel { get; set; }
-        public WristAdjustPanel? WristAdjustPanel { get; set; }
-        public DebugPanel? DebugPanel { get; set; }
-
-        // Panel Displays
-        public ChatPanel? ChatPanel { get; set; }
 
         protected PanelHost(string name)
         {
@@ -40,25 +31,37 @@ namespace TwitchChat
         /// <summary>Name of the panel currently shown on this host. Persisted in settings.</summary>
         public abstract string ActivePanel { get; set; }
 
+        /// <summary>Every panel built for this host, in the order the registry offered them.</summary>
+        public IEnumerable<BasePanel> Panels => panels.Values;
+
+        /// <summary>Adds a panel under the id displays remember it by.</summary>
+        public void AddPanel(string id, BasePanel panel) => panels[id] = panel;
+
+        /// <summary>Forgets every panel, for when the canvas carrying them has gone.</summary>
+        public void ClearPanels() => panels.Clear();
+
+        /// <summary>The panel with this id, or null if this host has not got one.</summary>
+        public BasePanel? GetPanel(string id) => panels.TryGetValue(id, out BasePanel? panel) ? panel : null;
+
+        /// <summary>
+        /// The panel of a given type. Used by the few places that need to say something specific to one
+        /// panel, such as handing a chat message to the chat panel.
+        /// </summary>
+        public T? Get<T>() where T : BasePanel => panels.Values.OfType<T>().FirstOrDefault();
+
+        /// <summary>The panel that shows incoming chat, if this host has one.</summary>
+        public ChatPanel? ChatPanel => Get<ChatPanel>();
+
         /// <summary>
         /// Puts a close button on every panel of this host. Hosts that cannot be closed, such as the wrist
         /// panel, simply never call this and their close buttons stay hidden.
         /// </summary>
         public void SetCloseAction(Action? action)
         {
-            MainPanel?.SetCloseAction(action);
-            AuthenticationPanel?.SetCloseAction(action);
-            StatusPanel?.SetCloseAction(action);
-            NotificationsPanel?.SetCloseAction(action);
-            StandardMessagesPanel?.SetCloseAction(action);
-            CommandMessagesPanel?.SetCloseAction(action);
-            TimedMessagesPanel?.SetCloseAction(action);
-            Config1Panel?.SetCloseAction(action);
-            Config2Panel?.SetCloseAction(action);
-            DisplaysPanel?.SetCloseAction(action);
-            WristAdjustPanel?.SetCloseAction(action);
-            DebugPanel?.SetCloseAction(action);
-            ChatPanel?.SetCloseAction(action);
+            foreach (BasePanel panel in panels.Values)
+            {
+                panel.SetCloseAction(action);
+            }
         }
     }
 

--- a/PanelMenus/Authentication.cs
+++ b/PanelMenus/Authentication.cs
@@ -151,6 +151,9 @@ namespace TwitchChat.PanelMenus
             UpdateAuthenticationPanelValues();
         }
 
+        /// <inheritdoc/>
+        public override void Tick(float deltaTime) => UpdateAuthenticationPanelValues();
+
         /// <summary>
         /// Brings every control on the panel into line with the current authentication state.
         /// Called from the menu update loop, so it must stay cheap and allocation-free.

--- a/PanelMenus/CommandMessages.cs
+++ b/PanelMenus/CommandMessages.cs
@@ -84,6 +84,9 @@ namespace TwitchChat.PanelMenus
             infoMessage = PanelConstructor.DisplayText.Create(commandsSettingsSection.transform, "", 10, 102, Color.cyan, 7);
         }
 
+        /// <inheritdoc/>
+        public override void Tick(float deltaTime) => UpdateCommandMessagesPanelValues();
+
         /// <summary>
         /// Updates the displayed values for command messages and info messages.
         /// Should be called when settings are changed.

--- a/PanelMenus/Main.cs
+++ b/PanelMenus/Main.cs
@@ -43,8 +43,11 @@ namespace TwitchChat.PanelMenus
             CreateMenuButton("Config1", 210, -35); // Offset to the left
             CreateMenuButton("Config2", 210, 35);  // Offset to the right
 
-            // Chat, sized by dragging the display it is on rather than by picking a preset
-            CreateMenuButton("Chat", 235);
+            // Chat, sized by dragging the display it is on rather than by picking a preset, beside the way
+            // in to whatever panels other mods have contributed. This menu has no room to grow, so plugin
+            // panels are listed on the Mods panel rather than added here one by one
+            CreateMenuButton("Chat", 235, -35);
+            CreateMenuButton("Mods", 235, 35);
 
             // Cab display controls side by side
             CreateActionButton("Place Display", 260, -42, () => MenuManager.Instance.PlaceCabDisplay());

--- a/PanelMenus/Mods.cs
+++ b/PanelMenus/Mods.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using TwitchChat.Plugins;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.PanelMenus
+{
+    /// <summary>
+    /// Lists the panels contributed by plugins, with a button to open each and a switch to turn each one
+    /// off. The main menu has a fixed set of buttons and no room to grow, so plugin panels gather here
+    /// instead and the list can be as long as it likes.
+    /// </summary>
+    /// <remarks>
+    /// A plugin whose mod is not installed does not appear at all. One the player has switched off is
+    /// listed, so it can be switched back on, but no display carries its panel: switching it back on takes
+    /// effect the next time the display's panel stack is built, which is on boarding a locomotive.
+    /// </remarks>
+    public class ModsPanel : PanelConstructor.BasePanel
+    {
+        private const int RowHeight = 46;
+        private const int FirstRowY = 35;
+
+        private readonly PanelHost? host;
+        private readonly List<GameObject> rows = new();
+
+        /// <param name="parent">The parent transform this panel will be attached to.</param>
+        /// <param name="host">The host this menu belongs to, or null for the hidden template copy.</param>
+        public ModsPanel(Transform parent, PanelHost? host) : base(parent)
+        {
+            this.host = host;
+            Rebuild();
+        }
+
+        /// <summary>
+        /// Redraws the list. Called when the panel is opened, since a plugin can be switched off from one
+        /// display and the others need to catch up.
+        /// </summary>
+        public void Rebuild()
+        {
+            foreach (GameObject row in rows)
+            {
+                Object.Destroy(row);
+            }
+            rows.Clear();
+
+            List<PanelDescriptor> plugins = PanelRegistry.AllPlugins.ToList();
+
+            if (plugins.Count == 0)
+            {
+                AddLabel("No mod panels are installed.", 5, FirstRowY);
+                AddLabel("Panels for other mods live in the", 5, FirstRowY + 18);
+                AddLabel("mod's Plugins folder.", 5, FirstRowY + 36);
+                return;
+            }
+
+            for (int i = 0; i < plugins.Count; i++)
+            {
+                PanelDescriptor plugin = plugins[i];
+                int y = FirstRowY + (i * RowHeight);
+
+                bool switchedOff = Settings.Instance.IsPanelDisabled(plugin.Id);
+                bool present = host?.GetPanel(plugin.Id) != null;
+
+                AddLabel(plugin.Title, 5, y);
+                AddOpenButton(plugin, y + 18, 55, enabled: present);
+                AddEnableButton(plugin, y + 18, 150, switchedOff);
+            }
+        }
+
+        private void AddLabel(string text, int x, int y)
+        {
+            Text label = PanelConstructor.Label.Create(panelObject.transform, text, x, y, Color.white);
+            rows.Add(label.gameObject);
+        }
+
+        /// <summary>
+        /// Opens the plugin's panel on this display. Greyed out when this display has no such panel, which
+        /// happens for a plugin switched on since the display was built, or one whose mod has gone away.
+        /// </summary>
+        private void AddOpenButton(PanelDescriptor plugin, int y, int x, bool enabled)
+        {
+            Button button = PanelConstructor.Button.Create(
+                panelObject.transform,
+                enabled ? "Open" : "Reboard",
+                x,
+                y,
+                enabled ? Color.white : Color.gray,
+                () =>
+                {
+                    if (enabled && host != null)
+                    {
+                        MenuManager.Instance.OnPanelButtonClicked(plugin.Id, host);
+                    }
+                },
+                70);
+
+            rows.Add(button.gameObject);
+        }
+
+        /// <summary>
+        /// Turns a plugin panel on or off. Taking effect on the next rebuild rather than at once is
+        /// deliberate: tearing a panel out from under a display while it is on screen is a good way to
+        /// leave a half-destroyed canvas behind.
+        /// </summary>
+        private void AddEnableButton(PanelDescriptor plugin, int y, int x, bool switchedOff)
+        {
+            Button? button = null;
+            button = PanelConstructor.Button.Create(
+                panelObject.transform,
+                switchedOff ? "Off" : "On",
+                x,
+                y,
+                Color.white,
+                () =>
+                {
+                    bool nowOff = !Settings.Instance.IsPanelDisabled(plugin.Id);
+                    Settings.Instance.SetPanelDisabled(plugin.Id, nowOff);
+
+                    Text? label = button != null ? button.GetComponentInChildren<Text>() : null;
+                    if (label != null)
+                    {
+                        label.text = nowOff ? "Off" : "On";
+                    }
+                },
+                40);
+
+            rows.Add(button.gameObject);
+        }
+    }
+}

--- a/PanelMenus/StandardMessages.cs
+++ b/PanelMenus/StandardMessages.cs
@@ -134,6 +134,9 @@ namespace TwitchChat.PanelMenus
         //     PanelConstructor.DisplayText.Create(newFollowerSubscriberSection.transform, "Future development", 10, 82, Color.yellow);
         // }
 
+        /// <inheritdoc/>
+        public override void Tick(float deltaTime) => UpdateStandardMessagesPanelValues();
+
         /// <summary>
         /// Updates the panel's values to reflect current settings.
         /// Should be called when settings are changed externally.

--- a/PanelMenus/Status.cs
+++ b/PanelMenus/Status.cs
@@ -104,6 +104,9 @@ namespace TwitchChat.PanelMenus
             lastKeepaliveTime = PanelConstructor.DisplayText.Create(wsSection.transform, WebSocketManager.lastKeepaliveTime.ToString("h:mm:ss tt"), 100, 160);
         }
 
+        /// <inheritdoc/>
+        public override void Tick(float deltaTime) => UpdateStatusPanelValues();
+
         /// <summary>
         /// Updates all status indicators and values in the panel.
         /// Should be called when any relevant status changes occur.

--- a/PanelMenus/WristAdjust.cs
+++ b/PanelMenus/WristAdjust.cs
@@ -117,6 +117,9 @@ namespace TwitchChat.PanelMenus
             return field;
         }
 
+        /// <inheritdoc/>
+        public override void Tick(float deltaTime) => UpdateValues();
+
         /// <summary>
         /// Redraws the numbers. They move on their own as well as by pressing the rows, since the panel can be
         /// carried into place by hand, so this runs while the panel is on show.

--- a/Plugins/AssemblyResolver.cs
+++ b/Plugins/AssemblyResolver.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace TwitchChat.Plugins
+{
+    /// <summary>
+    /// Teaches the runtime to look in the mod's own folder for the assemblies the mod ships beside its
+    /// main one, which is where TwitchChat.Api and any plugin's dependencies live.
+    /// </summary>
+    /// <remarks>
+    /// Nothing here may touch a type from TwitchChat.Api. The runtime resolves an assembly the first time
+    /// it compiles a method that mentions one of its types, so a resolver that mentioned them itself
+    /// would need to be resolved before it could run. Keeping this to plain framework types means
+    /// <see cref="Install"/> can safely be the first thing the mod does.
+    /// </remarks>
+    internal static class AssemblyResolver
+    {
+        private static string? modFolder;
+
+        /// <summary>
+        /// Starts resolving assembly loads out of the given folder. Safe to call more than once.
+        /// </summary>
+        /// <param name="folder">The mod's own folder, from its UMM entry.</param>
+        internal static void Install(string folder)
+        {
+            if (modFolder != null)
+            {
+                return;
+            }
+
+            modFolder = folder;
+            AppDomain.CurrentDomain.AssemblyResolve += Resolve;
+        }
+
+        private static Assembly? Resolve(object sender, ResolveEventArgs args)
+        {
+            if (modFolder == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                string simpleName = new AssemblyName(args.Name).Name;
+
+                // Anything already loaded is the one to hand back, so a plugin and the mod share a single
+                // copy of the API rather than each getting their own and failing to see the same types
+                foreach (Assembly loaded in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (loaded.GetName().Name == simpleName)
+                    {
+                        return loaded;
+                    }
+                }
+
+                foreach (string folder in new[] { modFolder, Path.Combine(modFolder, "Plugins") })
+                {
+                    string candidate = Path.Combine(folder, simpleName + ".dll");
+                    if (File.Exists(candidate))
+                    {
+                        return Assembly.LoadFrom(candidate);
+                    }
+                }
+            }
+            catch
+            {
+                // A resolver that throws breaks every load that follows it, including ones it has no
+                // business in, so anything going wrong here means "not mine"
+            }
+
+            return null;
+        }
+    }
+}

--- a/Plugins/PanelRegistry.cs
+++ b/Plugins/PanelRegistry.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TwitchChat.PanelConstructor;
+using UnityEngine;
+
+namespace TwitchChat.Plugins
+{
+    /// <summary>
+    /// One kind of panel a display can show. The mod's own panels and those contributed by plugins are
+    /// both described this way, so there is one list of panels rather than a built-in set and a bolted-on
+    /// second set.
+    /// </summary>
+    public sealed class PanelDescriptor
+    {
+        private readonly Func<Transform, PanelHost?, BasePanel> create;
+        private readonly Func<bool> available;
+
+        /// <param name="id">
+        /// Stable name for the panel. Written into settings as the panel a display was last showing, so
+        /// it must not change once released.
+        /// </param>
+        /// <param name="title">What the title row and the menu button read.</param>
+        /// <param name="isPlugin">True for panels contributed from outside the mod.</param>
+        /// <param name="create">Builds an instance of the panel under the given parent.</param>
+        /// <param name="available">Whether the panel should exist at all; defaults to always.</param>
+        public PanelDescriptor(
+            string id,
+            string title,
+            bool isPlugin,
+            Func<Transform, PanelHost?, BasePanel> create,
+            Func<bool>? available = null)
+        {
+            Id = id;
+            Title = title;
+            IsPlugin = isPlugin;
+            this.create = create;
+            this.available = available ?? (() => true);
+        }
+
+        public string Id { get; }
+        public string Title { get; }
+        public bool IsPlugin { get; }
+
+        /// <summary>
+        /// Whether a display should carry this panel. Plugin panels the player has switched off in the
+        /// Mods menu, and those whose mod is not installed, are left out entirely rather than shown empty.
+        /// </summary>
+        public bool IsAvailable
+        {
+            get
+            {
+                if (IsPlugin && Settings.Instance.IsPanelDisabled(Id))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    return available();
+                }
+                catch (Exception ex)
+                {
+                    Main.LogEntry("PanelDescriptor.IsAvailable", $"Panel '{Id}' failed its availability check and will be left out: {ex.Message}");
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the panel. A plugin that throws on the way up loses its panel and nothing else, so one
+        /// bad plugin cannot stop a display from being built.
+        /// </summary>
+        public BasePanel? Create(Transform parent, PanelHost? host)
+        {
+            try
+            {
+                return create(parent, host);
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("PanelDescriptor.Create", $"Panel '{Id}' failed to build and will be left out: {ex}");
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The list of panels a display can show, in menu order.
+    /// </summary>
+    /// <remarks>
+    /// Everything that used to be spelled out in five parallel places - the properties on a host, the
+    /// construction, the hiding, the showing, and the per-frame refresh - now comes from here, which is
+    /// what lets a panel arrive from a plugin without touching any of it.
+    /// </remarks>
+    public static class PanelRegistry
+    {
+        private static readonly List<PanelDescriptor> descriptors = new();
+        private static bool builtInsRegistered;
+
+        /// <summary>Every registered panel, whether or not it is currently available.</summary>
+        public static IReadOnlyList<PanelDescriptor> All => descriptors;
+
+        /// <summary>The panels a display should be built with right now.</summary>
+        public static IEnumerable<PanelDescriptor> Available => descriptors.Where(d => d.IsAvailable);
+
+        /// <summary>The available panels that came from plugins, which is what the Mods menu lists.</summary>
+        public static IEnumerable<PanelDescriptor> AvailablePlugins => Available.Where(d => d.IsPlugin);
+
+        /// <summary>Every plugin panel, including ones the player has switched off.</summary>
+        public static IEnumerable<PanelDescriptor> AllPlugins => descriptors.Where(d => d.IsPlugin);
+
+        public static PanelDescriptor? Find(string id) => descriptors.FirstOrDefault(d => d.Id == id);
+
+        /// <summary>
+        /// Adds a panel. A second panel claiming an id that is taken is refused, since the id is how a
+        /// display remembers what it was showing.
+        /// </summary>
+        public static bool Register(PanelDescriptor descriptor)
+        {
+            if (Find(descriptor.Id) != null)
+            {
+                Main.LogEntry("PanelRegistry.Register", $"Refused panel '{descriptor.Id}': that id is already registered.");
+                return false;
+            }
+
+            descriptors.Add(descriptor);
+            return true;
+        }
+
+        /// <summary>
+        /// Registers the mod's own panels. Called once before the first display is built.
+        /// </summary>
+        public static void RegisterBuiltIns()
+        {
+            if (builtInsRegistered)
+            {
+                return;
+            }
+
+            builtInsRegistered = true;
+
+            Add("Main", (parent, host) => new PanelMenus.MainPanel(parent, host));
+            Add("Authentication", (parent, _) => new PanelMenus.AuthenticationPanel(parent));
+            Add("Status", (parent, _) => new PanelMenus.StatusPanel(parent));
+            Add("Notifications", (parent, _) => new PanelMenus.NotificationsPanel(parent));
+            Add("Chat", (parent, _) => new PanelDisplays.ChatPanel(parent));
+            Add("Standard Messages", (parent, _) => new PanelMenus.StandardMessagesPanel(parent));
+            Add("Command Messages", (parent, _) => new PanelMenus.CommandMessagesPanel(parent));
+            Add("Timed Messages", (parent, _) => new PanelMenus.TimedMessagesPanel(parent));
+            Add("Config1", (parent, _) => new PanelMenus.Config1Panel(parent));
+            Add("Config2", (parent, _) => new PanelMenus.Config2Panel(parent));
+            Add("Displays", (parent, _) => new PanelMenus.DisplaysPanel(parent));
+            Add("Mods", (parent, host) => new PanelMenus.ModsPanel(parent, host));
+            Add("Wrist Adjust", (parent, _) => new PanelMenus.WristAdjustPanel(parent));
+            Add("Debug", (parent, _) => new PanelMenus.DebugPanel(parent));
+
+            static void Add(string id, Func<Transform, PanelHost?, BasePanel> create)
+            {
+                Register(new PanelDescriptor(id, id, isPlugin: false, create));
+            }
+        }
+    }
+}

--- a/Plugins/PluginLoader.cs
+++ b/Plugins/PluginLoader.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using TwitchChat.Api;
+
+namespace TwitchChat.Plugins
+{
+    /// <summary>
+    /// Finds the panels contributed from outside the mod and puts them in the registry alongside the
+    /// mod's own.
+    /// </summary>
+    /// <remarks>
+    /// Plugins arrive two ways. A mod that references TwitchChat.Api and calls
+    /// <see cref="TwitchChatPlugins.Register"/> is picked up whether it got there first or arrives later,
+    /// so neither mod needs to care about load order. An assembly dropped in the mod's Plugins folder is
+    /// found here instead, which is how the panels shipped with the mod get in and how a plugin can exist
+    /// for a mod that knows nothing about TwitchChat.
+    /// </remarks>
+    internal static class PluginLoader
+    {
+        private const string PluginFolderName = "Plugins";
+
+        private static bool loaded;
+
+        /// <summary>
+        /// Registers the mod's own panels, then everything the plugins offer. Called once during Load.
+        /// </summary>
+        /// <param name="modPath">The mod's own folder, from its UMM entry.</param>
+        internal static void LoadAll(string modPath)
+        {
+            if (loaded)
+            {
+                return;
+            }
+
+            loaded = true;
+
+            PanelRegistry.RegisterBuiltIns();
+
+            // Anything that registered before the mod got this far, plus anything that turns up after
+            foreach (ITwitchChatPlugin plugin in TwitchChatPlugins.Registered.ToList())
+            {
+                Adopt(plugin);
+            }
+
+            TwitchChatPlugins.PluginRegistered += Adopt;
+
+            LoadPluginAssemblies(Path.Combine(modPath, PluginFolderName));
+        }
+
+        /// <summary>
+        /// Turns a plugin into a panel the rest of the mod can treat like any other.
+        /// </summary>
+        private static void Adopt(ITwitchChatPlugin plugin)
+        {
+            string id;
+            string title;
+
+            try
+            {
+                id = plugin.Id;
+                title = plugin.Title;
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("PluginLoader", $"Ignoring plugin {plugin.GetType().FullName}: it threw when asked to name itself: {ex.Message}");
+                return;
+            }
+
+            bool registered = PanelRegistry.Register(new PanelDescriptor(
+                id,
+                title,
+                isPlugin: true,
+                create: (parent, _) => new PluginPanel(parent, plugin),
+                available: () => plugin.IsAvailable));
+
+            if (registered)
+            {
+                Main.LogEntry("PluginLoader", $"Registered plugin panel '{id}' from {plugin.GetType().Assembly.GetName().Name}.");
+            }
+        }
+
+        private static void LoadPluginAssemblies(string folder)
+        {
+            if (!Directory.Exists(folder))
+            {
+                Main.LogEntry("PluginLoader", $"No plugins folder at {folder}; only built-in panels are available.");
+                return;
+            }
+
+            foreach (string path in Directory.GetFiles(folder, "*.dll"))
+            {
+                // The API assembly lives beside the mod, not in here, but a tidy-minded player may well
+                // have copied it in; loading it as a plugin would find nothing and log a puzzling failure
+                if (Path.GetFileNameWithoutExtension(path) == "TwitchChat.Api")
+                {
+                    continue;
+                }
+
+                LoadPluginAssembly(path);
+            }
+        }
+
+        private static void LoadPluginAssembly(string path)
+        {
+            string name = Path.GetFileName(path);
+
+            try
+            {
+                Assembly assembly = Assembly.LoadFrom(path);
+
+                if (!ApiVersionMatches(assembly, out string mismatch))
+                {
+                    Main.LogEntry("PluginLoader", $"Skipped plugin {name}: {mismatch}");
+                    return;
+                }
+
+                int found = 0;
+                foreach (Type type in PluginTypesIn(assembly))
+                {
+                    if (Instantiate(type) is { } plugin)
+                    {
+                        TwitchChatPlugins.Register(plugin);
+                        found++;
+                    }
+                }
+
+                if (found == 0)
+                {
+                    Main.LogEntry("PluginLoader", $"Loaded {name} but it contained no usable plugin.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("PluginLoader", $"Failed to load plugin {name}: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Checks the plugin was built against a compatible API. A plugin that predates a breaking change
+        /// is refused here, with a line saying so, rather than throwing something unreadable later on.
+        /// </summary>
+        private static bool ApiVersionMatches(Assembly assembly, out string reason)
+        {
+            Version ours = typeof(TwitchChatPlugins).Assembly.GetName().Version;
+            AssemblyName? reference = assembly.GetReferencedAssemblies()
+                .FirstOrDefault(a => a.Name == "TwitchChat.Api");
+
+            if (reference == null)
+            {
+                reason = "it does not reference TwitchChat.Api, so it is not a plugin.";
+                return false;
+            }
+
+            if (reference.Version.Major != ours.Major)
+            {
+                reason = $"it was built against TwitchChat.Api {reference.Version} and this is {ours}. It needs rebuilding.";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        private static IEnumerable<Type> PluginTypesIn(Assembly assembly)
+        {
+            Type[] types;
+
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // A plugin referencing something absent still yields the types that did load, which is
+                // usually enough: a panel for a mod that is not installed is exactly the case to survive
+                types = ex.Types.Where(t => t != null).ToArray()!;
+                Main.LogEntry("PluginLoader", $"Some types in {assembly.GetName().Name} could not be loaded: {ex.LoaderExceptions.FirstOrDefault()?.Message}");
+            }
+
+            return types.Where(t =>
+                t != null &&
+                t.IsClass &&
+                !t.IsAbstract &&
+                typeof(ITwitchChatPlugin).IsAssignableFrom(t) &&
+                t.GetConstructor(Type.EmptyTypes) != null);
+        }
+
+        private static ITwitchChatPlugin? Instantiate(Type type)
+        {
+            try
+            {
+                return (ITwitchChatPlugin?)Activator.CreateInstance(type);
+            }
+            catch (Exception ex)
+            {
+                Main.LogEntry("PluginLoader", $"Could not create plugin {type.FullName}: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/Plugins/PluginPanel.cs
+++ b/Plugins/PluginPanel.cs
@@ -1,0 +1,125 @@
+using System;
+using TwitchChat.Api;
+using UnityEngine;
+
+namespace TwitchChat.Plugins
+{
+    /// <summary>
+    /// A display panel whose content comes from a plugin. It is an ordinary panel as far as the rest of
+    /// the mod is concerned - it has the same title row, back and close buttons, and scrolling area - and
+    /// it doubles as the surface the plugin draws on.
+    /// </summary>
+    /// <remarks>
+    /// Everything the plugin does is wrapped: a plugin that throws loses its own panel and says so on it,
+    /// rather than taking down the display it is on or the frame it threw in.
+    /// </remarks>
+    internal sealed class PluginPanel : PanelConstructor.BasePanel, IPanelSurface
+    {
+        private readonly ITwitchChatPlugin plugin;
+        private IPanelContent? content;
+        private Vector2 lastSize;
+
+        public PluginPanel(Transform parent, ITwitchChatPlugin plugin) : base(parent, plugin.Title)
+        {
+            this.plugin = plugin;
+
+            try
+            {
+                content = plugin.CreateContent(this);
+            }
+            catch (Exception ex)
+            {
+                Fault("could not build its content", ex);
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Panel behaviour, forwarded to the plugin
+        // ------------------------------------------------------------------
+
+        protected override void OnShown()
+        {
+            Guard("showing", () => content?.OnShow());
+
+            // A display can be resized while showing something else, so tell the plugin where it stands
+            // the moment it comes back rather than waiting for the next drag
+            NotifyResizeIfChanged();
+        }
+
+        protected override void OnHidden() => Guard("hiding", () => content?.OnHide());
+
+        public override void Tick(float deltaTime)
+        {
+            NotifyResizeIfChanged();
+            Guard("updating", () => content?.Tick(deltaTime));
+        }
+
+        public override void OnResize(Vector2 size)
+        {
+            lastSize = size;
+            Guard("resizing", () => content?.OnResize(size));
+        }
+
+        // ------------------------------------------------------------------
+        // IPanelSurface: what the plugin is given to draw on
+        // ------------------------------------------------------------------
+
+        public Transform Root => panelObject.transform;
+
+        public Transform Content => contentRectTransform;
+
+        public Vector2 Size => rectTransform != null ? rectTransform.rect.size : MenuManager.DefaultPanelSize;
+
+        public IWidgetFactory Widgets => WidgetFactory.Instance;
+
+        public void Log(string message) => Main.LogEntry($"Plugin:{plugin.Id}", message);
+
+        // ------------------------------------------------------------------
+
+        private void NotifyResizeIfChanged()
+        {
+            Vector2 size = Size;
+            if (size != lastSize && size.x > 0f && size.y > 0f)
+            {
+                OnResize(size);
+            }
+        }
+
+        private void Guard(string what, Action action)
+        {
+            if (content == null)
+            {
+                return;
+            }
+
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Fault($"threw while {what}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Stops driving the plugin and says so on the panel. Done once: a plugin that throws every frame
+        /// would otherwise fill the log and cost a frame's worth of exceptions each time.
+        /// </summary>
+        private void Fault(string what, Exception ex)
+        {
+            content = null;
+            Main.LogEntry("PluginPanel", $"Panel '{plugin.Id}' {what} and has been stopped: {ex}");
+
+            try
+            {
+                PanelConstructor.Label.Create(panelObject.transform, $"{plugin.Title} stopped", 10, 40, Color.red);
+                PanelConstructor.DisplayText.Create(panelObject.transform, ex.Message, 10, 60, Color.gray, lines: 4);
+            }
+            catch (Exception labelFailure)
+            {
+                Main.LogEntry("PluginPanel", $"Could not even report the failure of '{plugin.Id}': {labelFailure.Message}");
+            }
+        }
+    }
+}

--- a/Plugins/PluginPanel.cs
+++ b/Plugins/PluginPanel.cs
@@ -72,7 +72,23 @@ namespace TwitchChat.Plugins
 
         public IWidgetFactory Widgets => WidgetFactory.Instance;
 
+        public void ReserveHeader(float height)
+        {
+            // The scrolling area is anchored to fill the panel below the title row; moving its top edge
+            // down is all that is needed to leave a plugin's header the room it asked for
+            RectTransform? scrollRect = scrollableArea != null ? scrollableArea.GetComponent<RectTransform>() : null;
+            if (scrollRect == null)
+            {
+                return;
+            }
+
+            scrollRect.offsetMax = new Vector2(scrollRect.offsetMax.x, -(TitleRowHeight + Mathf.Max(0f, height)));
+        }
+
         public void Log(string message) => Main.LogEntry($"Plugin:{plugin.Id}", message);
+
+        /// <summary>Room the title row and its buttons take, matching what BasePanel leaves for them.</summary>
+        private const float TitleRowHeight = 35f;
 
         // ------------------------------------------------------------------
 

--- a/Plugins/WidgetFactory.cs
+++ b/Plugins/WidgetFactory.cs
@@ -1,0 +1,56 @@
+using System;
+using TwitchChat.Api;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+namespace TwitchChat.Plugins
+{
+    /// <summary>
+    /// Hands the mod's own widget factories to plugins through the public interface, so a plugin panel is
+    /// built out of exactly the same parts as the mod's panels: same fonts, same VR poke colliders, and
+    /// the same object naming the colour settings key off.
+    /// </summary>
+    internal sealed class WidgetFactory : IWidgetFactory
+    {
+        internal static readonly WidgetFactory Instance = new();
+
+        private WidgetFactory() { }
+
+        public Text CreateLabel(Transform parent, string text, int x, int y, Color? color = null)
+            => PanelConstructor.Label.Create(parent, text, x, y, color);
+
+        public Text CreateText(Transform parent, string text, int x, int y, Color? color = null, int lines = 1, int fontSize = 12)
+            => PanelConstructor.DisplayText.Create(parent, text, x, y, color, lines, fontSize);
+
+        public void CreateTitle(Transform parent, string text, int fontSize = 16, Color? color = null)
+            => PanelConstructor.Title.Create(parent, text, fontSize, color);
+
+        public GameObject CreateSection(Transform parent, string name, int y, int height, bool withLabel = true)
+            => PanelConstructor.Section.Create(parent, name, y, height, withLabel);
+
+        public GameObject CreateSeparator(Transform parent, int y, Color? color = null)
+            => PanelConstructor.HorizontalBar.Create(parent, y, color);
+
+        public Button CreateButton(Transform parent, string text, int x, int y, Color? color = null, Action? clicked = null, int? width = null)
+            => PanelConstructor.Button.Create(parent, text, x, y, color, Wrap(clicked), width);
+
+        public Toggle CreateToggle(Transform parent, int x, int y, string textOn, string textOff, bool initialState = true, Color? onColor = null, Color? offColor = null, Action<bool>? changed = null)
+            => PanelConstructor.Toggle.Create(parent, x, y, textOn, textOff, initialState, onColor, offColor, Wrap(changed));
+
+        public Slider CreateSlider(Transform parent, int x, int y, float min = 0f, float max = 1f, float value = 0.5f, Action<float>? changed = null)
+            => PanelConstructor.Slider.Create(parent, x, y, min, max, value, Wrap(changed));
+
+        public GameObject CreateValueBar(Transform parent, string label, int y, Color? fillColor = null)
+            => PanelConstructor.ValueBar.Create(parent, label, y, fillColor);
+
+        public void SetValueBar(GameObject bar, float fraction, string? valueText = null)
+            => PanelConstructor.ValueBar.SetValue(bar, fraction, valueText);
+
+        // The public API speaks in plain delegates so a plugin need not care that the widgets underneath
+        // are uGUI; these turn them back into the UnityEvent callbacks those widgets want
+        private static UnityAction? Wrap(Action? action) => action == null ? null : new UnityAction(action);
+
+        private static UnityAction<T>? Wrap<T>(Action<T>? action) => action == null ? null : new UnityAction<T>(action);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - Subscriber/Follower alerts and notifications
 - Message throttling and combining for busy chats
 - User list management (VIP, ignore, etc.)
-- Integration with "Remote Dispatch" mod
+- More detail on the Dispatch Map panel: job list, car list, and throwing junctions from in game
 - Display panel scrolling in VR
 - Editing timed message text and intervals from the in-game panel, instead of the Unity Mod Manager menu or Settings.xml
 
@@ -213,6 +213,15 @@ Access advanced options by expanding the "Debug and Troubleshooting" section in 
 - [GitHub Repository](https://github.com/Nightwind416/Derail-Valley-Twitch-Chat-Mod)
 
 ## Version History
+
+### 3.5.0 (September 6, 2026)
+
+- The displays are open to panels from other mods. Several mods work out things worth knowing while driving and then draw them to the flat screen, where a headset never sees them; those readouts can now live on a cab display or the wrist panel instead. A new **Mods** panel, reachable from any Main panel, lists what is installed with a switch to turn each one off
+- **Metrics** panel, showing the consist figures from DSH's Loco Metrics mod: cars, axles, length, mass, braked mass and percentage, handbrakes, brake line and rear pipe pressure, with bars for throttle and the brakes. It honours that mod's own settings for which figures to show
+- **AI Traffic** panel, showing what every AI train is doing: state, speed against target, throttle and brake, where it is and where it is going, and how far to the next signal. Four switches turn that mod's own loco nametags, route lines, signal tags and HUD on and off, so the ones drawn in the world can be reached without taking the headset off
+- **Dispatch Map** panel, a live map of the railway drawn from Remote Dispatch's data: track, junctions and which way each is thrown, every car, every locomotive and every player, with zoom, panning and a Follow mode. It reads the mod in process, so there is no port to open and no need to have its web server switched on
+- Each panel appears only if the mod it reports on is installed, and each is read from that mod's own live data rather than reimplemented, so nothing has to be kept in step by hand
+- If you write mods yourself, this is a documented, public plugin API rather than three special cases: see [docs/PLUGINS.md](docs/PLUGINS.md)
 
 ### 3.4.2 (September 4, 2026)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ The menus and chat displays live on world-space panels. There are two kinds of p
 -- Wrist Adjust - Move and turn the wrist panel on your hand, or grab it and put it there by hand in VR
 -- Debug - Set debug level, several 'debug and testing' related buttons
 
+### Panels From Other Mods
+
+Several mods show things worth reading while driving, but all of them draw to the flat screen, where
+a headset never sees them. The **Mods** panel, reachable from any Main panel, lists panels that put
+that information on a display instead. Each is drawn from the other mod's own live data, so there is
+nothing to keep in step by hand, and each appears only if the mod it reports on is installed. Switch
+any of them off from the Mods panel or the Unity Mod Manager menu; changes apply the next time you
+board a locomotive.
+
+- **Metrics** — the consist figures from
+  [Unrestored Museum Loco Tracker And Loco Metrics](https://github.com/DmytroShulha/DerailValley_mod_MuseumAndMetrics)
+  by DSH: cars, axles, length, total, tare and cargo mass, braked mass and percentage, handbrakes set,
+  whether the brake line is continuous, rear pipe pressure, locomotives running, and hazmat cars, with
+  bars for throttle, train brake, loco brake and dynamic brake. It honours that mod's own settings for
+  which figures to show, so the panel matches its overlay
+
+If you write mods yourself, the displays are open to yours as well: see [docs/PLUGINS.md](docs/PLUGINS.md).
+
 - Buttons can be interacted with in both VR and non-VR modes
 - Top left panel buttons will 'minimize' the displayed panel
 - Top right panel buttons return to the 'Main' panel, and close the display on cab displays. From the Main panel, back does nothing on a cab display and folds the wrist panel away to its button

--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ board a locomotive.
   signal tags and its screen HUD - so the three that are drawn in the world, and are therefore worth
   having in VR, can be reached without taking the headset off
 
+- **Dispatch Map** — a live map of the railway from
+  [Remote Dispatch](https://github.com/mspielberg/dv-remote-dispatch) by mspielberg. That mod shows all
+  of this already, but as a web page in a browser, which is exactly what someone in a headset has not
+  got. The panel draws the track, the junctions and which way each is thrown, every car, every
+  locomotive and every player, with zoom, panning, and a Follow mode that keeps you in the middle. It
+  reads the mod's data directly, so there is no port to open, no password, and no need to have the web
+  server switched on. It is an overview: no job list, no car list, no locomotive control - use the web
+  page for those
+
 If you write mods yourself, the displays are open to yours as well: see [docs/PLUGINS.md](docs/PLUGINS.md).
 
 - Buttons can be interacted with in both VR and non-VR modes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - **Automated Messages**: Schedule up to five periodic announcements, each posted in the color you pick - normal, blue, green, orange, purple, or your channel accent
 - **Displays You Size Yourself**: Up to 5 panels per locomotive, each dragged to whatever size suits it
 - **Color Customization**: Ability to customize panel, section, and button coloring
+- **Panels From Other Mods**: The displays are open to plugins, so readouts that only ever existed on the flat screen can be put where you can read them in VR. See [docs/PLUGINS.md](docs/PLUGINS.md) if you write mods
 
 ### Upcoming Features (In Development)
 
@@ -80,6 +81,7 @@ The menus and chat displays live on world-space panels. There are two kinds of p
 -- Command Messages - Enable/Disable the !info and !command ...commands
 -- Timed Messages - Enable/Disable the timed messages system
 -- Displays - List the displays in this locomotive, lock the position or size of each, and close the ones you are done with
+-- Mods - Panels contributed by other mods, with a switch to turn each one off. Empty until you install one
 -- Wrist Adjust - Move and turn the wrist panel on your hand, or grab it and put it there by hand in VR
 -- Debug - Set debug level, several 'debug and testing' related buttons
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - **Real-Time Chat Display**: View Twitch chat messages through in-game display panels (and popup notifications)
 - **Authentication You Can Audit**: OAuth handled directly between you and Twitch, asking for only the four permissions the mod actually uses, revocable from inside the game
 - **Message Logging**: Detailed chat logs for post-stream review
-- **Automated Messages**: Schedule periodic announcements to keep your chat informed
+- **Automated Messages**: Schedule up to five periodic announcements, each posted in the color you pick - normal, blue, green, orange, purple, or your channel accent
 - **Displays You Size Yourself**: Up to 5 panels per locomotive, each dragged to whatever size suits it
 - **Color Customization**: Ability to customize panel, section, and button coloring
 
@@ -19,8 +19,8 @@ A mod that seamlessly integrates Twitch chat into your Derail Valley gameplay ex
 - Message throttling and combining for busy chats
 - User list management (VIP, ignore, etc.)
 - Integration with "Remote Dispatch" mod
-- Colored announcement system for timed messages
 - Display panel scrolling in VR
+- Editing timed message text and intervals from the in-game panel, instead of the Unity Mod Manager menu or Settings.xml
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ board a locomotive.
   bars for throttle, train brake, loco brake and dynamic brake. It honours that mod's own settings for
   which figures to show, so the panel matches its overlay
 
+- **AI Traffic** — the debug overlay from [AI Traffic](https://github.com/Killermops27/dv-ai-traffic) by
+  Killermops27, which is otherwise flat-screen only. How the traffic is set up and how many trains are
+  running, then a scrolling list of every AI train: its ID and state, speed against target speed,
+  throttle and brake, where it is and where it is going, and how far to the next signal or obstacle.
+  Four switches along the top turn that mod's own displays on and off - loco nametags, route lines,
+  signal tags and its screen HUD - so the three that are drawn in the world, and are therefore worth
+  having in VR, can be reached without taking the headset off
+
 If you write mods yourself, the displays are open to yours as well: see [docs/PLUGINS.md](docs/PLUGINS.md).
 
 - Buttons can be interacted with in both VR and non-VR modes

--- a/Settings.cs
+++ b/Settings.cs
@@ -165,10 +165,6 @@ namespace TwitchChat
         public string timedMessage5 = "MessageNotSet";
         public float timedMessage5Timer = 0;
 
-        // Dispatcher Messages Settings
-        public bool dispatcherMessageActive = false;
-        public string dispatcherMessage = "MessageNotSet";
-
         // Color Options for announcement messages
         public readonly string[] ColorOptions = ["Normal", "Blue", "Green", "Orange", "Purple", "Primary"];
         private int message1ColorIndex = 0;

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityModManagerNet;
 
@@ -74,6 +75,13 @@ namespace TwitchChat
 
         /// <summary>Every saved display, for every locomotive type. Grouped by <see cref="CabDisplayPose.carId"/>.</summary>
         public List<CabDisplayPose> cabDisplayPoses = new();
+
+        /// <summary>
+        /// Ids of the plugin panels the player has switched off, separated by commas. Kept as one string
+        /// rather than a list so the Unity Mod Manager page and the settings file both stay readable, and
+        /// so a plugin that is not installed keeps its setting instead of being quietly dropped.
+        /// </summary>
+        public string disabledPanels = string.Empty;
         public bool wristPanelEnabled = true;
         public string wristPanel = "Main";
         public bool wristPanelOnLeftHand = true;
@@ -473,6 +481,10 @@ namespace TwitchChat
 
             GUILayout.Space(10);
 
+            DrawModPanels();
+
+            GUILayout.Space(10);
+
             // Debug Settings Section
             GUILayout.BeginVertical(GUI.skin.box);
                 GUILayout.Label("Debug Level");
@@ -505,6 +517,80 @@ namespace TwitchChat
         public void Update()
         {
             _ = this;
+        }
+
+        /// <summary>
+        /// Draws the list of panels contributed by plugins, so a player can see what was found and switch
+        /// any of it off without going in game. The same list, with the same switches, is on the in-game
+        /// Mods panel.
+        /// </summary>
+        private void DrawModPanels()
+        {
+            GUILayout.BeginVertical(GUI.skin.box);
+                GUILayout.Label("Mod Panels");
+
+                List<Plugins.PanelDescriptor> plugins = Plugins.PanelRegistry.AllPlugins.ToList();
+                if (plugins.Count == 0)
+                {
+                    GUILayout.Label("    None installed. Panels for other mods are dropped into the mod's Plugins folder.");
+                }
+
+                foreach (Plugins.PanelDescriptor plugin in plugins)
+                {
+                    bool off = IsPanelDisabled(plugin.Id);
+
+                    GUILayout.BeginHorizontal();
+                        if (GUILayout.Button(off ? "Off" : "On", GUILayout.Width(50)))
+                        {
+                            SetPanelDisabled(plugin.Id, !off);
+                        }
+                        GUILayout.Label(plugin.Title, GUILayout.Width(160));
+
+                        // The panel exists for the mod it reports on, so saying whether that mod was found
+                        // is the answer to "why is this panel not in my menu"
+                        GUILayout.Label(off
+                            ? "switched off"
+                            : plugin.IsAvailable ? "ready" : "the mod it reports on was not found");
+                    GUILayout.EndHorizontal();
+                }
+
+                if (plugins.Count > 0)
+                {
+                    GUILayout.Label("    Changes apply the next time you board a locomotive, when the displays are rebuilt.");
+                }
+            GUILayout.EndVertical();
+        }
+
+        /// <summary>Whether the player has switched a plugin panel off.</summary>
+        public bool IsPanelDisabled(string panelId) => DisabledPanelIds().Contains(panelId);
+
+        /// <summary>
+        /// Switches a plugin panel on or off. Takes effect the next time a display's panel stack is built,
+        /// which is on boarding a locomotive.
+        /// </summary>
+        public void SetPanelDisabled(string panelId, bool disabled)
+        {
+            List<string> ids = DisabledPanelIds();
+
+            if (disabled)
+            {
+                if (ids.Contains(panelId)) return;
+                ids.Add(panelId);
+            }
+            else if (!ids.Remove(panelId))
+            {
+                return;
+            }
+
+            disabledPanels = string.Join(",", ids);
+            RequestSave();
+        }
+
+        private List<string> DisabledPanelIds()
+        {
+            return string.IsNullOrWhiteSpace(disabledPanels)
+                ? new List<string>()
+                : disabledPanels.Split(',').Select(id => id.Trim()).Where(id => id.Length > 0).ToList();
         }
 
         // Deferred saving: panel sliders fire on every tick, so writes are coalesced and flushed after a short quiet period.

--- a/TwitchChat.Api/IPanelContent.cs
+++ b/TwitchChat.Api/IPanelContent.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// One plugin panel on one display. Created by <see cref="ITwitchChatPlugin.CreateContent"/> and then
+    /// driven by TwitchChat for as long as that display exists.
+    /// </summary>
+    public interface IPanelContent
+    {
+        /// <summary>The panel has just been brought to the front of its display.</summary>
+        void OnShow();
+
+        /// <summary>The panel has just been hidden, because another one was shown or the display closed.</summary>
+        void OnHide();
+
+        /// <summary>
+        /// Called once a frame while the panel is showing. Reading another mod's state every frame is
+        /// rarely worth it; keep your own timer and refresh a few times a second instead.
+        /// </summary>
+        /// <param name="deltaTime">Seconds since the last call.</param>
+        void Tick(float deltaTime);
+
+        /// <summary>
+        /// The display has been dragged to a new size, in canvas units. Panels have no size of their own:
+        /// a display is whatever size the player has made it, so lay out against this rather than against
+        /// any fixed dimensions.
+        /// </summary>
+        void OnResize(Vector2 size);
+    }
+}

--- a/TwitchChat.Api/IPanelSurface.cs
+++ b/TwitchChat.Api/IPanelSurface.cs
@@ -35,6 +35,16 @@ namespace TwitchChat.Api
         /// </summary>
         IWidgetFactory Widgets { get; }
 
+        /// <summary>
+        /// Keeps the top of the panel clear of the scrolling area, so a header placed on
+        /// <see cref="Root"/> is not sat on by whatever is in <see cref="Content"/>.
+        /// </summary>
+        /// <param name="height">
+        /// How much room the header needs below the title row, in canvas units. Zero puts the scrolling
+        /// area back where it started.
+        /// </param>
+        void ReserveHeader(float height);
+
         /// <summary>Writes a line to the mod's log, tagged with the plugin's id.</summary>
         void Log(string message);
     }

--- a/TwitchChat.Api/IPanelSurface.cs
+++ b/TwitchChat.Api/IPanelSurface.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// The piece of a display a plugin panel draws on, handed to
+    /// <see cref="ITwitchChatPlugin.CreateContent"/>.
+    /// </summary>
+    /// <remarks>
+    /// There are two places to put things, matching how the mod's own panels are built:
+    /// <see cref="Root"/> for anything placed at a fixed spot, such as a header or a row of buttons, and
+    /// <see cref="Content"/> for a list that grows, which scrolls and lays itself out top to bottom.
+    /// </remarks>
+    public interface IPanelSurface
+    {
+        /// <summary>
+        /// The panel itself. Widgets parented here are positioned by hand, in canvas units measured down
+        /// from the top, and are not scrolled. The title row occupies roughly the first 30 units.
+        /// </summary>
+        Transform Root { get; }
+
+        /// <summary>
+        /// The scrolling area's content. Children are laid out vertically and the area scrolls when they
+        /// no longer fit, so this is where a list of rows belongs. Widgets from
+        /// <see cref="IWidgetFactory"/> that take a position ignore it here; the layout decides.
+        /// </summary>
+        Transform Content { get; }
+
+        /// <summary>The display's current size in canvas units. Changes when the player drags an edge.</summary>
+        Vector2 Size { get; }
+
+        /// <summary>
+        /// Builds widgets that match the mod's own, including the object naming its colour settings key
+        /// off, so a plugin panel is themed along with everything else.
+        /// </summary>
+        IWidgetFactory Widgets { get; }
+
+        /// <summary>Writes a line to the mod's log, tagged with the plugin's id.</summary>
+        void Log(string message);
+    }
+}

--- a/TwitchChat.Api/ITwitchChatPlugin.cs
+++ b/TwitchChat.Api/ITwitchChatPlugin.cs
@@ -1,0 +1,38 @@
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// A panel contributed by something other than TwitchChat itself. Implement this to put your own
+    /// content on the mod's world-space displays: the cab displays in a locomotive and the VR wrist panel.
+    /// </summary>
+    /// <remarks>
+    /// TwitchChat creates one <see cref="IPanelContent"/> per plugin per display, so a plugin instance may
+    /// be asked for content several times over and must not assume there is only one of it on screen.
+    /// Everything is called on Unity's main thread.
+    /// </remarks>
+    public interface ITwitchChatPlugin
+    {
+        /// <summary>
+        /// Stable identifier for this panel, unique across all plugins. It is written into the player's
+        /// settings as the panel a display was last showing, so changing it loses that choice. Something
+        /// like "AI Traffic" or "MyMod.Speedometer".
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>The name shown in the panel's title bar and on its button in the Mods menu.</summary>
+        string Title { get; }
+
+        /// <summary>
+        /// Whether this panel should exist at all right now, typically "is the mod I am reporting on
+        /// installed". Checked when a display's panel stack is built, so it should be cheap and it should
+        /// not depend on the world being loaded. Content that is merely not ready yet is better handled
+        /// by the panel saying so than by disappearing from the menu.
+        /// </summary>
+        bool IsAvailable { get; }
+
+        /// <summary>
+        /// Builds the panel's content onto the surface it is given. Called once per display, when that
+        /// display's panel stack is created, whether or not the panel is the one currently shown.
+        /// </summary>
+        IPanelContent CreateContent(IPanelSurface surface);
+    }
+}

--- a/TwitchChat.Api/IWidgetFactory.cs
+++ b/TwitchChat.Api/IWidgetFactory.cs
@@ -1,0 +1,60 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// Builds the same widgets the mod's own panels are made of. Using these rather than raw uGUI keeps a
+    /// plugin panel looking like the rest of the mod, gets it the VR poke colliders on anything clickable,
+    /// and gets it recoloured along with everything else when the player changes the colour settings.
+    /// </summary>
+    /// <remarks>
+    /// Positions are in canvas units measured down and right from the top left of the parent. Widgets
+    /// parented to <see cref="IPanelSurface.Content"/> are laid out by the scroll area instead, so their
+    /// positions are ignored there.
+    /// </remarks>
+    public interface IWidgetFactory
+    {
+        /// <summary>A short one-line caption.</summary>
+        Text CreateLabel(Transform parent, string text, int x, int y, Color? color = null);
+
+        /// <summary>A block of text that can wrap over several lines.</summary>
+        Text CreateText(Transform parent, string text, int x, int y, Color? color = null, int lines = 1, int fontSize = 12);
+
+        /// <summary>A heading across the top of an area.</summary>
+        void CreateTitle(Transform parent, string text, int fontSize = 16, Color? color = null);
+
+        /// <summary>
+        /// A shaded box to group related widgets in, optionally labelled with its name. Parent your rows
+        /// to the returned object to keep them together.
+        /// </summary>
+        GameObject CreateSection(Transform parent, string name, int y, int height, bool withLabel = true);
+
+        /// <summary>A thin horizontal rule.</summary>
+        GameObject CreateSeparator(Transform parent, int y, Color? color = null);
+
+        /// <summary>A button, pokeable in VR and clickable outside it.</summary>
+        Button CreateButton(Transform parent, string text, int x, int y, Color? color = null, Action? clicked = null, int? width = null);
+
+        /// <summary>A two-state toggle showing one of two captions.</summary>
+        Toggle CreateToggle(Transform parent, int x, int y, string textOn, string textOff, bool initialState = true, Color? onColor = null, Color? offColor = null, Action<bool>? changed = null);
+
+        /// <summary>A slider. In VR each press advances it about a tenth and then wraps.</summary>
+        Slider CreateSlider(Transform parent, int x, int y, float min = 0f, float max = 1f, float value = 0.5f, Action<float>? changed = null);
+
+        /// <summary>
+        /// A labelled bar for showing a fraction of something, such as a throttle position. Set the value
+        /// afterwards with <see cref="SetValueBar"/>.
+        /// </summary>
+        GameObject CreateValueBar(Transform parent, string label, int y, Color? fillColor = null);
+
+        /// <summary>
+        /// Updates a bar made by <see cref="CreateValueBar"/>.
+        /// </summary>
+        /// <param name="bar">The object returned by <see cref="CreateValueBar"/>.</param>
+        /// <param name="fraction">How full the bar is, from 0 to 1. Values outside that range are clamped.</param>
+        /// <param name="valueText">Text shown at the right of the bar, or null to show a percentage.</param>
+        void SetValueBar(GameObject bar, float fraction, string? valueText = null);
+    }
+}

--- a/TwitchChat.Api/ModBinder.cs
+++ b/TwitchChat.Api/ModBinder.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityModManagerNet;
+
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// Reads another mod's public runtime API by reflection, with everything cached and every failure
+    /// turned into a null rather than an exception.
+    /// </summary>
+    /// <remarks>
+    /// Reflection is the right tool here even when the other mod is open source: referencing its assembly
+    /// directly would make TwitchChat fail to load whenever that mod is absent, and it would tie the two
+    /// mods' versions together. Binding by name instead means a panel degrades to "that mod is not
+    /// installed", or to a missing row, rather than taking the whole mod down with it.
+    /// <para>
+    /// A binder holds no game state, so it is safe to create one in a plugin's constructor and bind
+    /// lazily. Nothing here touches the world.
+    /// </para>
+    /// </remarks>
+    public sealed class ModBinder
+    {
+        private readonly Dictionary<string, Type?> types = new();
+        private readonly Dictionary<string, MemberInfo?> members = new();
+
+        private UnityModManager.ModEntry? modEntry;
+        private Assembly? assembly;
+        private bool failed;
+
+        /// <param name="modId">The other mod's UMM id, as it appears in its info.json.</param>
+        public ModBinder(string modId)
+        {
+            ModId = modId;
+        }
+
+        /// <summary>The UMM id this binder is looking for.</summary>
+        public string ModId { get; }
+
+        /// <summary>Why binding failed, in a few words, or null while nothing has gone wrong.</summary>
+        public string? Error { get; private set; }
+
+        /// <summary>
+        /// Whether the mod is installed and switched on. Cheap once resolved, and it keeps looking until
+        /// it finds the mod, so it can be called before the other mod has finished loading.
+        /// </summary>
+        public bool IsModPresent
+        {
+            get
+            {
+                if (failed)
+                {
+                    return false;
+                }
+
+                modEntry ??= UnityModManager.FindMod(ModId);
+                return modEntry is { Active: true };
+            }
+        }
+
+        /// <summary>The other mod's assembly once it has loaded, or null.</summary>
+        public Assembly? Assembly
+        {
+            get
+            {
+                if (assembly != null || !IsModPresent)
+                {
+                    return assembly;
+                }
+
+                try
+                {
+                    assembly = modEntry?.Assembly;
+                }
+                catch (Exception ex)
+                {
+                    Fail($"could not reach the assembly of '{ModId}': {ex.Message}");
+                }
+
+                return assembly;
+            }
+        }
+
+        /// <summary>
+        /// Stops this binder for good, so a mod whose shape is not what was expected is reported once
+        /// rather than throwing on every frame.
+        /// </summary>
+        public void Fail(string reason)
+        {
+            if (failed)
+            {
+                return;
+            }
+
+            failed = true;
+            Error = reason;
+        }
+
+        /// <summary>Looks up a type by its full name, or null if it is not there.</summary>
+        public Type? Type(string fullName)
+        {
+            if (types.TryGetValue(fullName, out Type? cached))
+            {
+                return cached;
+            }
+
+            Type? found = null;
+            try
+            {
+                found = Assembly?.GetType(fullName, throwOnError: false);
+            }
+            catch (Exception ex)
+            {
+                Fail($"looking up type '{fullName}' in '{ModId}' threw: {ex.Message}");
+            }
+
+            // Only remember the answer once the assembly is actually there, so a lookup made too early
+            // does not cache a null for the rest of the session
+            if (Assembly != null)
+            {
+                types[fullName] = found;
+            }
+
+            return found;
+        }
+
+        /// <summary>Looks up a public static or instance method, matching on name alone.</summary>
+        public MethodInfo? Method(Type? owner, string name)
+        {
+            return Member(owner, name, "m", t => t.GetMethod(name, PublicAny)) as MethodInfo;
+        }
+
+        /// <summary>Looks up a public property.</summary>
+        public PropertyInfo? Property(Type? owner, string name)
+        {
+            return Member(owner, name, "p", t => t.GetProperty(name, PublicAny)) as PropertyInfo;
+        }
+
+        /// <summary>Looks up a public field.</summary>
+        public FieldInfo? Field(Type? owner, string name)
+        {
+            return Member(owner, name, "f", t => t.GetField(name, PublicAny)) as FieldInfo;
+        }
+
+        /// <summary>
+        /// Reads a property or field by name off an object, whichever it turns out to be. Handy for
+        /// walking a result struct whose shape may change between versions of the other mod: a member
+        /// that is no longer there simply reads as null.
+        /// </summary>
+        public object? Read(object? target, string name)
+        {
+            if (target == null)
+            {
+                return null;
+            }
+
+            Type owner = target.GetType();
+
+            try
+            {
+                PropertyInfo? property = Property(owner, name);
+                if (property != null)
+                {
+                    return property.GetValue(target);
+                }
+
+                FieldInfo? field = Field(owner, name);
+                return field?.GetValue(target);
+            }
+            catch (Exception ex)
+            {
+                Fail($"reading '{owner.Name}.{name}' from '{ModId}' threw: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Reads a value type off an object by name, falling back to the given default when the member is
+        /// missing or holds something unexpected.
+        /// </summary>
+        public T ReadOr<T>(object? target, string name, T fallback)
+        {
+            object? value = Read(target, name);
+            return value is T typed ? typed : fallback;
+        }
+
+        /// <summary>Calls a method, returning null rather than throwing if anything goes wrong.</summary>
+        public object? Invoke(MethodInfo? method, object? target, params object?[] args)
+        {
+            if (method == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return method.Invoke(target, args);
+            }
+            catch (Exception ex)
+            {
+                // The interesting exception is the one the other mod threw, not the reflection wrapper
+                Exception cause = ex is TargetInvocationException { InnerException: { } inner } ? inner : ex;
+                Fail($"calling '{method.DeclaringType?.Name}.{method.Name}' in '{ModId}' threw: {cause.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Writes a public field or property, and reports whether it worked.</summary>
+        public bool Write(object? target, string name, object? value)
+        {
+            Type? owner = target?.GetType();
+            if (owner == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                PropertyInfo? property = Property(owner, name);
+                if (property is { CanWrite: true })
+                {
+                    property.SetValue(target, value);
+                    return true;
+                }
+
+                FieldInfo? field = Field(owner, name);
+                if (field != null)
+                {
+                    field.SetValue(target, value);
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Fail($"writing '{owner.Name}.{name}' in '{ModId}' threw: {ex.Message}");
+            }
+
+            return false;
+        }
+
+        private const BindingFlags PublicAny =
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
+
+        private MemberInfo? Member(Type? owner, string name, string kind, Func<Type, MemberInfo?> lookup)
+        {
+            if (owner == null)
+            {
+                return null;
+            }
+
+            string key = $"{kind}:{owner.FullName}.{name}";
+            if (members.TryGetValue(key, out MemberInfo? cached))
+            {
+                return cached;
+            }
+
+            MemberInfo? found = null;
+            try
+            {
+                found = lookup(owner);
+            }
+            catch (Exception ex)
+            {
+                Fail($"looking up '{owner.Name}.{name}' in '{ModId}' threw: {ex.Message}");
+            }
+
+            members[key] = found;
+            return found;
+        }
+    }
+}

--- a/TwitchChat.Api/ModBinder.cs
+++ b/TwitchChat.Api/ModBinder.cs
@@ -174,6 +174,32 @@ namespace TwitchChat.Api
             }
         }
 
+        /// <summary>Reads a public static property or field off a type, whichever it turns out to be.</summary>
+        public object? ReadStatic(Type? owner, string name)
+        {
+            if (owner == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                PropertyInfo? property = Property(owner, name);
+                if (property != null)
+                {
+                    return property.GetValue(null);
+                }
+
+                FieldInfo? field = Field(owner, name);
+                return field?.GetValue(null);
+            }
+            catch (Exception ex)
+            {
+                Fail($"reading static '{owner.Name}.{name}' from '{ModId}' threw: {ex.Message}");
+                return null;
+            }
+        }
+
         /// <summary>
         /// Reads a value type off an object by name, falling back to the given default when the member is
         /// missing or holds something unexpected.
@@ -182,6 +208,65 @@ namespace TwitchChat.Api
         {
             object? value = Read(target, name);
             return value is T typed ? typed : fallback;
+        }
+
+        /// <summary>
+        /// Reads a number off an object by name, whatever numeric type the other mod happens to use for
+        /// it. Worth having: whether a figure is stored as a float, a double or an int is exactly the sort
+        /// of detail that changes between versions and should not cost a row on a panel.
+        /// </summary>
+        public float ReadFloat(object? target, string name, float fallback = 0f)
+        {
+            return AsFloat(Read(target, name), fallback);
+        }
+
+        /// <summary>Reads a whole number off an object by name, rounding if it is stored as a fraction.</summary>
+        public int ReadInt(object? target, string name, int fallback = 0)
+        {
+            object? value = Read(target, name);
+            if (value == null)
+            {
+                return fallback;
+            }
+
+            try
+            {
+                return Convert.ToInt32(value);
+            }
+            catch (Exception)
+            {
+                return fallback;
+            }
+        }
+
+        /// <summary>Reads a flag off an object by name.</summary>
+        public bool ReadBool(object? target, string name, bool fallback = false)
+        {
+            return Read(target, name) is bool value ? value : fallback;
+        }
+
+        /// <summary>Reads text off an object by name, using the value's own ToString if it is not a string.</summary>
+        public string ReadString(object? target, string name, string fallback = "")
+        {
+            object? value = Read(target, name);
+            return value == null ? fallback : value as string ?? value.ToString();
+        }
+
+        private static float AsFloat(object? value, float fallback)
+        {
+            if (value == null)
+            {
+                return fallback;
+            }
+
+            try
+            {
+                return Convert.ToSingle(value);
+            }
+            catch (Exception)
+            {
+                return fallback;
+            }
         }
 
         /// <summary>Calls a method, returning null rather than throwing if anything goes wrong.</summary>

--- a/TwitchChat.Api/TwitchChat.Api.csproj
+++ b/TwitchChat.Api/TwitchChat.Api.csproj
@@ -13,7 +13,7 @@
 			The version third-party plugins compile against. Bump the minor for additive changes and the
 			major for anything that breaks an existing plugin; TwitchChatPlugins.ApiVersion must match.
 		-->
-		<Version>1.1.0</Version>
+		<Version>1.2.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/TwitchChat.Api/TwitchChat.Api.csproj
+++ b/TwitchChat.Api/TwitchChat.Api.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>TwitchChat.Api</AssemblyName>
+		<RootNamespace>TwitchChat.Api</RootNamespace>
+		<TargetFramework>net48</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
+		<OutputType>Library</OutputType>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+		<DebugType>none</DebugType>
+		<!--
+			The version third-party plugins compile against. Bump the minor for additive changes and the
+			major for anything that breaks an existing plugin; TwitchChatPlugins.ApiVersion must match.
+		-->
+		<Version>1.0.0</Version>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Reference Include="UnityEngine">
+			<HintPath>$(DerailValleyManagedAssets)UnityEngine.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>$(DerailValleyManagedAssets)UnityEngine.CoreModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.UIModule">
+			<HintPath>$(DerailValleyManagedAssets)UnityEngine.UIModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.UI">
+			<HintPath>$(DerailValleyManagedAssets)UnityEngine.UI.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.TextRenderingModule">
+			<HintPath>$(DerailValleyManagedAssets)UnityEngine.TextRenderingModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityModManager">
+			<HintPath>$(DerailValleyManagedAssets)UnityModManager\UnityModManager.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+	</ItemGroup>
+
+	<Target Name="CopyApiToMods" AfterTargets="PostBuildEvent">
+		<MakeDir Directories="$(ModOutputPath)" />
+		<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(ModOutputPath)" />
+	</Target>
+</Project>

--- a/TwitchChat.Api/TwitchChatPlugins.cs
+++ b/TwitchChat.Api/TwitchChatPlugins.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TwitchChat.Api
+{
+    /// <summary>
+    /// Where plugins announce themselves to TwitchChat.
+    /// </summary>
+    /// <remarks>
+    /// There are two ways in and they end up in the same place. A mod that already exists can reference
+    /// this assembly and call <see cref="Register"/> from its own Load, in which case load order does not
+    /// matter: TwitchChat picks up whatever is here when it starts and is told about anything registered
+    /// afterwards. Alternatively a plugin assembly dropped in the mod's Plugins folder is found and
+    /// registered by TwitchChat itself, with no code in the other mod at all.
+    /// </remarks>
+    public static class TwitchChatPlugins
+    {
+        /// <summary>
+        /// The version of this contract. TwitchChat refuses plugins built against a different major
+        /// version, so a plugin compiled against an old API says so plainly instead of failing oddly.
+        /// </summary>
+        public const int ApiVersion = 1;
+
+        private static readonly List<ITwitchChatPlugin> registered = new();
+
+        /// <summary>Everything registered so far, in the order it arrived.</summary>
+        public static IReadOnlyList<ITwitchChatPlugin> Registered => registered;
+
+        /// <summary>Raised when a plugin registers, so TwitchChat hears about late arrivals.</summary>
+        public static event Action<ITwitchChatPlugin>? PluginRegistered;
+
+        /// <summary>
+        /// Offers a plugin to TwitchChat. Safe to call before TwitchChat has loaded. A second plugin
+        /// claiming an id that is already taken is refused, since the id is what the player's settings
+        /// remember a display by.
+        /// </summary>
+        /// <returns>True if the plugin was accepted.</returns>
+        public static bool Register(ITwitchChatPlugin plugin)
+        {
+            if (plugin == null)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(plugin.Id))
+            {
+                Debug.LogWarning($"[TwitchChat.Api] Refused a plugin of type {plugin.GetType().FullName} because its Id is empty.");
+                return false;
+            }
+
+            foreach (ITwitchChatPlugin existing in registered)
+            {
+                if (existing.Id == plugin.Id)
+                {
+                    Debug.LogWarning($"[TwitchChat.Api] Refused plugin '{plugin.Id}' from {plugin.GetType().FullName}: that id is already registered by {existing.GetType().FullName}.");
+                    return false;
+                }
+            }
+
+            registered.Add(plugin);
+            PluginRegistered?.Invoke(plugin);
+            return true;
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficBridge.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficBridge.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TwitchChat.Api;
+using UnityEngine;
+
+namespace TwitchChat.Plugins.Bundled.AiTraffic
+{
+    /// <summary>
+    /// Reads Killermops27's AI Traffic mod: which AI trains are running, what each is doing, and the
+    /// switches for its own world-space route lines and nametags.
+    /// </summary>
+    /// <remarks>
+    /// That mod keeps its overlay as a pure view over <c>AIEngineer</c>, which exposes everything as
+    /// public properties, and reaches them through a <c>TrafficManager</c> singleton. That is a better
+    /// seam than most, and it is the only one available: the mod has no licence file at all, so nothing
+    /// here is copied from it and nothing is referenced. Its public runtime API is read and that is all.
+    /// </remarks>
+    internal sealed class AiTrafficBridge
+    {
+        internal const string ModId = "AITraffic";
+
+        private readonly ModBinder binder = new(ModId);
+
+        private Type? managerType;
+        private bool lookedUp;
+
+        internal bool IsInstalled => binder.IsModPresent;
+
+        internal string? Error => binder.Error;
+
+        /// <summary>The mod's own settings object, whose flags the panel offers to flip.</summary>
+        private object? Settings => binder.ReadStatic(Type("AITraffic.Main"), "Settings");
+
+        /// <summary>The traffic manager, or null before a world is loaded and traffic has started.</summary>
+        private object? Manager
+        {
+            get
+            {
+                Bind();
+                return binder.ReadStatic(managerType, "Instance");
+            }
+        }
+
+        /// <summary>Whether the mod is actually dispatching trains, as opposed to merely installed.</summary>
+        internal bool IsRunning
+        {
+            get
+            {
+                Bind();
+                return binder.ReadStatic(managerType, "IsRunning") is true;
+            }
+        }
+
+        /// <summary>How the mod is set up: ambient traffic or worker-driven, and how much of it.</summary>
+        internal string Mode => binder.ReadString(Settings, "Mode", "unknown");
+
+        internal string Density => binder.ReadString(Settings, "Density", "unknown");
+
+        internal int MaxTrains => binder.ReadInt(Settings, "MaxActiveTrains");
+
+        internal int ActiveTrainCount => binder.ReadInt(Manager, "ActiveTrainCount");
+
+        /// <summary>
+        /// The AI drivers currently at the controls of something. Empty rather than null whenever the mod
+        /// has nothing to say, so a caller need not tell "no trains" from "no mod".
+        /// </summary>
+        internal IEnumerable<object> Engineers()
+        {
+            if (binder.Read(Manager, "ActiveEngineers") is not IEnumerable list)
+            {
+                yield break;
+            }
+
+            foreach (object? engineer in list)
+            {
+                if (engineer != null)
+                {
+                    yield return engineer;
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // One AI driver
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// The locomotive an AI driver is aboard. Its driver is a component on the car, so this needs no
+        /// reflection at all: TrainCar is the game's own type and both mods see the same one.
+        /// </summary>
+        internal TrainCar? CarOf(object engineer)
+        {
+            return engineer is Component component ? component.GetComponent<TrainCar>() : null;
+        }
+
+        internal float SpeedKmh(object engineer) => binder.ReadFloat(engineer, "CurrentSpeedKmh");
+
+        internal float TargetSpeedKmh(object engineer) => binder.ReadFloat(engineer, "TargetSpeedKmh");
+
+        internal string State(object engineer) => binder.ReadString(engineer, "State", "?");
+
+        internal float Throttle(object engineer) => binder.ReadFloat(engineer, "CommandedThrottle");
+
+        internal float TrainBrake(object engineer) => binder.ReadFloat(engineer, "CommandedTrainBrake");
+
+        internal float DynamicBrake(object engineer) => binder.ReadFloat(engineer, "CommandedDynamicBrake");
+
+        internal float DistanceToSignal(object engineer) => binder.ReadFloat(engineer, "DistanceToSignal", float.NaN);
+
+        internal float DistanceToObstacle(object engineer) => binder.ReadFloat(engineer, "DistanceToObstacle", float.NaN);
+
+        internal bool IsWorkerDriven(object engineer) => binder.ReadBool(engineer, "IsWorkerDriven");
+
+        /// <summary>Where the mod says a train is, in its own words, or empty if it will not say.</summary>
+        internal string LocationOf(TrainCar? car)
+        {
+            if (car == null)
+            {
+                return string.Empty;
+            }
+
+            Bind();
+            return binder.Invoke(binder.Method(managerType, "GetTrainLocationDescription"), null, car) as string ?? string.Empty;
+        }
+
+        /// <summary>Where the mod says a train is going, in its own words.</summary>
+        internal string DestinationOf(object engineer)
+        {
+            Bind();
+            string described = binder.Invoke(binder.Method(managerType, "GetTrainDestinationDescription"), null, engineer) as string ?? string.Empty;
+
+            // Older builds may not have the helper, in which case the station name is the next best thing
+            return described.Length > 0 ? described : binder.ReadString(engineer, "DestinationStationName");
+        }
+
+        // ------------------------------------------------------------------
+        // The mod's own displays
+        // ------------------------------------------------------------------
+
+        /// <summary>Whether one of the mod's own overlays is switched on.</summary>
+        internal bool ShowsOverlay(string flag) => binder.ReadBool(Settings, flag);
+
+        /// <summary>
+        /// Switches one of the mod's own overlays on or off. Its route lines, signal tags and loco
+        /// nametags are drawn in the world, so they are worth having in VR - and until now the only way
+        /// to reach them was the Unity Mod Manager menu, which means taking the headset off.
+        /// </summary>
+        internal void ToggleOverlay(string flag)
+        {
+            object? settings = Settings;
+            binder.Write(settings, flag, !binder.ReadBool(settings, flag));
+        }
+
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Finds the mod's types once. Namespaces are the sort of thing that gets rearranged between
+        /// versions, so each is tried in a couple of plausible places before giving up.
+        /// </summary>
+        private void Bind()
+        {
+            if (lookedUp)
+            {
+                return;
+            }
+
+            lookedUp = true;
+            managerType = Type("AITraffic.Core.TrafficManager", "AITraffic.TrafficManager");
+
+            if (managerType == null && binder.Assembly != null)
+            {
+                binder.Fail("TrafficManager was not found; this version of the mod is not one this panel knows.");
+            }
+        }
+
+        private Type? Type(params string[] candidates)
+        {
+            foreach (string candidate in candidates)
+            {
+                if (binder.Type(candidate) is { } found)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficBridge.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficBridge.cs
@@ -86,12 +86,13 @@ namespace TwitchChat.Plugins.Bundled.AiTraffic
         // ------------------------------------------------------------------
 
         /// <summary>
-        /// The locomotive an AI driver is aboard. Its driver is a component on the car, so this needs no
-        /// reflection at all: TrainCar is the game's own type and both mods see the same one.
+        /// The locomotive an AI driver is aboard. The mod says so itself; failing that, the driver is a
+        /// component on the car, and TrainCar is the game's own type that both mods see the same one of.
         /// </summary>
         internal TrainCar? CarOf(object engineer)
         {
-            return engineer is Component component ? component.GetComponent<TrainCar>() : null;
+            return binder.Read(engineer, "TrainCar") as TrainCar
+                ?? (engineer as Component)?.GetComponent<TrainCar>();
         }
 
         internal float SpeedKmh(object engineer) => binder.ReadFloat(engineer, "CurrentSpeedKmh");

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TwitchChat.Api;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.Plugins.Bundled.AiTraffic
+{
+    /// <summary>
+    /// A header saying how the AI traffic is set up and how much of it is running, a row of switches for
+    /// the mod's own world-space overlays, and a scrolling list of every AI train with what it is doing.
+    /// </summary>
+    internal sealed class AiTrafficContent : IPanelContent
+    {
+        /// <summary>
+        /// How often the trains are re-read. Ten AI drivers each answering a dozen questions is not free,
+        /// and none of the answers change fast enough to be worth a frame.
+        /// </summary>
+        private const float RefreshInterval = 0.4f;
+
+        /// <summary>Room the header and the switches need, in canvas units, below the title row.</summary>
+        private const float HeaderHeight = 78f;
+
+        private const int CaptionX = 10;
+        private const int ValueX = 105;
+
+        /// <summary>
+        /// The mod's own overlays, by the settings field each is stored in. The three world-space ones
+        /// are the point of this: they are drawn in the world, so a headset can see them, and the only
+        /// other way to reach them is the Unity Mod Manager menu.
+        /// </summary>
+        private static readonly (string Flag, string Caption)[] Overlays =
+        {
+            ("ShowLocoTags", "Locos"),
+            ("ShowRouteVisualizer", "Path"),
+            ("ShowSignalTags", "Signals"),
+            ("DebugVisuals", "HUD")
+        };
+
+        private readonly IPanelSurface surface;
+        private readonly AiTrafficBridge traffic;
+
+        private readonly List<GameObject> trainRows = new();
+        private readonly Dictionary<string, Text> overlayLabels = new();
+
+        private Text? summary;
+        private Text? counts;
+        private float untilRefresh;
+
+        internal AiTrafficContent(IPanelSurface surface, AiTrafficBridge traffic)
+        {
+            this.surface = surface;
+            this.traffic = traffic;
+
+            surface.ReserveHeader(HeaderHeight);
+            BuildHeader();
+        }
+
+        public void OnShow() => Refresh();
+
+        public void OnHide() { }
+
+        public void OnResize(Vector2 size) { }
+
+        public void Tick(float deltaTime)
+        {
+            untilRefresh -= deltaTime;
+            if (untilRefresh > 0f)
+            {
+                return;
+            }
+
+            untilRefresh = RefreshInterval;
+            Refresh();
+        }
+
+        // ------------------------------------------------------------------
+
+        private void BuildHeader()
+        {
+            surface.Widgets.CreateLabel(surface.Root, "Traffic", CaptionX, 35, Color.gray);
+            summary = surface.Widgets.CreateText(surface.Root, "--", ValueX, 35, Color.white);
+
+            surface.Widgets.CreateLabel(surface.Root, "Trains", CaptionX, 53, Color.gray);
+            counts = surface.Widgets.CreateText(surface.Root, "--", ValueX, 53, Color.white);
+
+            // Four switches across the panel. Buttons are positioned by their centre, so they are spread
+            // about the middle rather than laid out from the left edge
+            const int buttonWidth = 52;
+            int x = -((Overlays.Length - 1) * buttonWidth) / 2;
+
+            foreach ((string flag, string caption) in Overlays)
+            {
+                string overlay = flag;
+                Button button = surface.Widgets.CreateButton(
+                    surface.Root,
+                    caption,
+                    x,
+                    76,
+                    Color.white,
+                    () =>
+                    {
+                        traffic.ToggleOverlay(overlay);
+                        UpdateOverlayButtons();
+                    },
+                    buttonWidth - 4);
+
+                Text? label = button.GetComponentInChildren<Text>();
+                if (label != null)
+                {
+                    overlayLabels[flag] = label;
+                }
+
+                x += buttonWidth;
+            }
+
+            UpdateOverlayButtons();
+        }
+
+        /// <summary>Colours each switch by whether that overlay is currently on.</summary>
+        private void UpdateOverlayButtons()
+        {
+            foreach (KeyValuePair<string, Text> entry in overlayLabels)
+            {
+                entry.Value.color = traffic.ShowsOverlay(entry.Key) ? Color.cyan : Color.gray;
+            }
+        }
+
+        private void Refresh()
+        {
+            UpdateOverlayButtons();
+
+            if (summary != null)
+            {
+                summary.text = traffic.IsRunning
+                    ? $"{traffic.Mode}, {traffic.Density}"
+                    : "not running";
+            }
+
+            List<object> engineers = traffic.Engineers().ToList();
+
+            if (counts != null)
+            {
+                int max = traffic.MaxTrains;
+                int active = traffic.ActiveTrainCount;
+
+                // The manager's own count and the list it hands out should agree; when they do not, the
+                // list is the one that has rows behind it, so say both rather than pick
+                counts.text = active == engineers.Count
+                    ? $"{active} of {max}"
+                    : $"{engineers.Count} listed, {active} of {max}";
+            }
+
+            RebuildTrainList(engineers);
+        }
+
+        /// <summary>
+        /// Redraws the list of trains. One text block per train rather than a widget per figure: the list
+        /// is rebuilt on every refresh, and a dozen objects per train would make that expensive.
+        /// </summary>
+        private void RebuildTrainList(List<object> engineers)
+        {
+            foreach (GameObject row in trainRows)
+            {
+                Object.Destroy(row);
+            }
+            trainRows.Clear();
+
+            if (engineers.Count == 0)
+            {
+                string message = traffic.Error
+                    ?? (traffic.IsRunning ? "No AI trains are running just now." : "AI traffic is not running.");
+                AddRow(message, Color.gray);
+                return;
+            }
+
+            foreach (object engineer in engineers)
+            {
+                AddRow(Describe(engineer), Color.white);
+            }
+        }
+
+        private string Describe(object engineer)
+        {
+            TrainCar? car = traffic.CarOf(engineer);
+            StringBuilder text = new();
+
+            string id = car != null ? car.ID : "unknown";
+            text.Append(id).Append("  ").Append(traffic.State(engineer));
+
+            if (traffic.IsWorkerDriven(engineer))
+            {
+                text.Append("  (worker)");
+            }
+
+            text.AppendLine();
+            text.Append($"  {traffic.SpeedKmh(engineer):F0} of {traffic.TargetSpeedKmh(engineer):F0} km/h");
+            text.Append($"   T {Percent(traffic.Throttle(engineer))}  B {Percent(traffic.TrainBrake(engineer))}");
+
+            float dynamic = traffic.DynamicBrake(engineer);
+            if (dynamic > 0.01f)
+            {
+                text.Append($"  D {Percent(dynamic)}");
+            }
+
+            string location = traffic.LocationOf(car);
+            string destination = traffic.DestinationOf(engineer);
+            if (location.Length > 0 || destination.Length > 0)
+            {
+                text.AppendLine();
+                text.Append("  ").Append(location.Length > 0 ? location : "?");
+                text.Append(" to ").Append(destination.Length > 0 ? destination : "?");
+            }
+
+            string ahead = Ahead(traffic.DistanceToSignal(engineer), "signal");
+            string obstacle = Ahead(traffic.DistanceToObstacle(engineer), "ahead");
+            if (ahead.Length > 0 || obstacle.Length > 0)
+            {
+                text.AppendLine();
+                text.Append("  ").Append(string.Join("   ", new[] { ahead, obstacle }.Where(part => part.Length > 0).ToArray()));
+            }
+
+            return text.ToString();
+        }
+
+        /// <summary>
+        /// A distance the mod may or may not have. It reports nothing in sight as an unusable number,
+        /// and a row reading "signal at infinity" helps nobody.
+        /// </summary>
+        private static string Ahead(float metres, string what)
+        {
+            return float.IsNaN(metres) || float.IsInfinity(metres) || metres <= 0f || metres > 10000f
+                ? string.Empty
+                : $"{what} {metres:F0} m";
+        }
+
+        private static string Percent(float fraction) => $"{Mathf.RoundToInt(Mathf.Clamp01(fraction) * 100f)}%";
+
+        private void AddRow(string text, Color color)
+        {
+            // Four lines' worth of room: the longest description runs to four, and the scrolling area
+            // gives each row whatever height it asks for
+            Text row = surface.Widgets.CreateText(surface.Content, text, 0, 0, color, lines: 4);
+            trainRows.Add(row.gameObject);
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
@@ -20,7 +20,7 @@ namespace TwitchChat.Plugins.Bundled.AiTraffic
         private const float RefreshInterval = 0.4f;
 
         /// <summary>Room the header and the switches need, in canvas units, below the title row.</summary>
-        private const float HeaderHeight = 78f;
+        private const float HeaderHeight = 55f;
 
         private const int CaptionX = 10;
         private const int ValueX = 105;

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficContent.cs
@@ -85,10 +85,10 @@ namespace TwitchChat.Plugins.Bundled.AiTraffic
             surface.Widgets.CreateLabel(surface.Root, "Trains", CaptionX, 53, Color.gray);
             counts = surface.Widgets.CreateText(surface.Root, "--", ValueX, 53, Color.white);
 
-            // Four switches across the panel. Buttons are positioned by their centre, so they are spread
-            // about the middle rather than laid out from the left edge
+            // Four switches in a row. A button is placed by its centre, measured from the panel's left
+            // edge, so the first sits half a button in
             const int buttonWidth = 52;
-            int x = -((Overlays.Length - 1) * buttonWidth) / 2;
+            int x = CaptionX + (buttonWidth / 2);
 
             foreach ((string flag, string caption) in Overlays)
             {

--- a/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficPlugin.cs
+++ b/TwitchChat.Plugins.Bundled/AiTraffic/AiTrafficPlugin.cs
@@ -1,0 +1,21 @@
+using TwitchChat.Api;
+
+namespace TwitchChat.Plugins.Bundled.AiTraffic
+{
+    /// <summary>
+    /// Puts the AI Traffic mod's debug overlay on a display: what the AI trains are doing, and the
+    /// switches for the mod's own route lines and nametags.
+    /// </summary>
+    public sealed class AiTrafficPlugin : ITwitchChatPlugin
+    {
+        private readonly AiTrafficBridge traffic = new();
+
+        public string Id => "AI Traffic";
+
+        public string Title => "AI Traffic";
+
+        public bool IsAvailable => traffic.IsInstalled;
+
+        public IPanelContent CreateContent(IPanelSurface surface) => new AiTrafficContent(surface, traffic);
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using TwitchChat.Api;
 using UnityEngine;
@@ -54,10 +53,10 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
     /// statics and quite separate from the HTTP layer, so the same figures its web page draws can be had
     /// in process - no port, no password, no dependency on the player having the server switched on.
     /// <para>
-    /// The methods used here return the JSON its own endpoints return, so the shapes below are the shapes
-    /// its own map already consumes: a public contract rather than an internal detail. Coordinates are
-    /// the mod's own flat latitude and longitude, metres divided by the earth's circumference, which is
-    /// only a projection convention and needs no undoing here.
+    /// The methods used here return what its own endpoints return, so the shapes below are the shapes its
+    /// own map already consumes: a public contract rather than an internal detail. Coordinates are the
+    /// mod's own flat latitude and longitude, metres divided by the earth's circumference, which is only
+    /// a projection convention and needs no undoing here.
     /// </para>
     /// </remarks>
     internal sealed class DispatchBridge
@@ -73,22 +72,91 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         private MethodInfo? playerJson;
         private bool lookedUp;
 
+        /// <summary>The track layout request, once made. See <see cref="TryReadTracks"/>.</summary>
+        private Task<string>? trackRequest;
+
+        private string diagnosis = "not looked up yet";
+
         internal bool IsInstalled => binder.IsModPresent;
 
         internal string? Error => binder.Error;
 
         /// <summary>
-        /// The whole track layout. Large, and it does not change during a session, so read it once.
+        /// What was and was not found when binding, for the log. Reading another mod by name is the part
+        /// of this most likely to break when that mod changes, and "the map stopped" on its own tells
+        /// nobody which of five lookups was the one that went missing.
         /// </summary>
-        internal List<TrackLine> Tracks()
+        internal string Diagnosis
+        {
+            get
+            {
+                Bind();
+                return diagnosis;
+            }
+        }
+
+        /// <summary>
+        /// The whole track layout, which is large and does not change during a session.
+        /// </summary>
+        /// <remarks>
+        /// This one is asynchronous on the other side: it hands the work to that mod's own main-thread
+        /// pump, because its usual caller is an HTTP worker thread. We are already on the main thread, so
+        /// waiting on the result here would stop the very loop that has to run for it to be produced, and
+        /// hang the game. Hence a request left in flight and picked up on a later frame.
+        /// </remarks>
+        /// <returns>Null while the answer is still coming, otherwise the tracks - empty if it failed.</returns>
+        internal List<TrackLine>? TryReadTracks()
         {
             Bind();
-            List<TrackLine> tracks = new();
 
-            if (Read(trackJson) is not { } json)
+            if (trackJson == null)
             {
-                return tracks;
+                return new List<TrackLine>();
             }
+
+            if (trackRequest == null)
+            {
+                object? result = binder.Invoke(trackJson, null, Arguments(trackJson));
+
+                switch (result)
+                {
+                    case null:
+                        return new List<TrackLine>();
+
+                    // Older builds answered directly; take that at once rather than making a frame of it
+                    case string immediate:
+                        return ParseTracks(immediate);
+
+                    case Task<string> pending:
+                        trackRequest = pending;
+                        break;
+
+                    default:
+                        binder.Fail($"RailTracks.GetTrackPointJSON returned {result.GetType().Name}, which this panel does not know how to read.");
+                        return new List<TrackLine>();
+                }
+            }
+
+            if (!trackRequest.IsCompleted)
+            {
+                return null;
+            }
+
+            Task<string> finished = trackRequest;
+            trackRequest = null;
+
+            if (finished.IsFaulted)
+            {
+                binder.Fail($"reading the track layout threw: {finished.Exception?.GetBaseException().Message}");
+                return new List<TrackLine>();
+            }
+
+            return ParseTracks(finished.Result);
+        }
+
+        private List<TrackLine> ParseTracks(string json)
+        {
+            List<TrackLine> tracks = new();
 
             // { "trackId": [[lat, lon], ...], ... }
             foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(json))
@@ -109,13 +177,13 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             Bind();
             List<Vector2> positions = new();
 
-            if (Read(junctionJson) is not { } json)
+            if (ReadJson(junctionJson) is not JArray entries)
             {
                 return positions;
             }
 
             // [ { "position": [lat, lon], "branches": [trackId, trackId] }, ... ]
-            foreach (JToken entry in JArray.Parse(json))
+            foreach (JToken entry in entries)
             {
                 if (Point(entry["position"]) is { } position)
                 {
@@ -134,13 +202,10 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         {
             Bind();
 
-            if (Read(junctionStateJson) is not { } json)
-            {
-                return Array.Empty<int>();
-            }
-
             // [ selectedBranch, ... ], one per junction, in the same order as the positions
-            return JArray.Parse(json).Select(state => state.Type == JTokenType.Integer ? (int)state : -1).ToArray();
+            return ReadJson(junctionStateJson) is not JArray states
+                ? Array.Empty<int>()
+                : states.Select(state => state.Type == JTokenType.Integer ? (int)state : -1).ToArray();
         }
 
         /// <summary>Every car the mod is willing to report, plus every player.</summary>
@@ -149,10 +214,10 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             Bind();
             List<MapMarker> markers = new();
 
-            if (Read(carJson) is { } cars)
+            if (ReadJson(carJson) is JObject cars)
             {
                 // { "carId": { "position": [lat, lon], "rotation": deg, ... }, ... }
-                foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(cars))
+                foreach (KeyValuePair<string, JToken?> entry in cars)
                 {
                     if (Marker(entry.Value, isPlayer: false) is { } marker)
                     {
@@ -164,10 +229,10 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 }
             }
 
-            if (Read(playerJson) is { } players)
+            if (ReadJson(playerJson) is JObject players)
             {
                 // { "playerId": { "color": name, "position": [lat, lon], "rotation": deg }, ... }
-                foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(players))
+                foreach (KeyValuePair<string, JToken?> entry in players)
                 {
                     if (Marker(entry.Value, isPlayer: true) is { } marker)
                     {
@@ -225,38 +290,36 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         }
 
         /// <summary>
-        /// Calls one of the mod's JSON methods and returns what it produced, or null.
+        /// Calls one of the mod's synchronous data methods and returns what it produced as JSON.
         /// </summary>
         /// <remarks>
-        /// Some of these are iterators that yield the document in pieces rather than returning it whole,
-        /// which is sensible when the other end is a socket and irrelevant here, so both shapes are
-        /// accepted and joined.
+        /// Some of these hand back a parsed document and some the text of one, which is the sort of
+        /// difference that should cost a line here rather than a panel.
         /// </remarks>
-        private string? Read(MethodInfo? method)
+        private JToken? ReadJson(MethodInfo? method)
         {
             object? result = binder.Invoke(method, null, Arguments(method));
 
-            switch (result)
+            try
             {
-                case null:
-                    return null;
-                case string json:
-                    return json;
-                case IEnumerable pieces:
-                    StringBuilder joined = new();
-                    foreach (object? piece in pieces)
-                    {
-                        joined.Append(piece);
-                    }
-                    return joined.ToString();
-                default:
-                    return result.ToString();
+                return result switch
+                {
+                    null => null,
+                    JToken token => token,
+                    string text => JToken.Parse(text),
+                    _ => null
+                };
+            }
+            catch (Exception ex)
+            {
+                binder.Fail($"the answer from '{method?.Name}' could not be read as JSON: {ex.Message}");
+                return null;
             }
         }
 
         /// <summary>
-        /// Fills in a method's optional parameters, so a version that takes, say, a resolution still
-        /// answers rather than failing on the argument count.
+        /// Fills in a method's parameters, so a version that takes, say, a resolution still answers
+        /// rather than failing on the argument count.
         /// </summary>
         private static object?[] Arguments(MethodInfo? method)
         {
@@ -277,18 +340,33 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
             lookedUp = true;
 
+            List<string> found = new();
+            List<string> missing = new();
+
             trackJson = Find("DvMod.RemoteDispatch.RailTracks", "GetTrackPointJSON");
             junctionJson = Find("DvMod.RemoteDispatch.Junctions", "GetJunctionPointJSON");
             junctionStateJson = Find("DvMod.RemoteDispatch.Junctions", "GetJunctionStateJSON");
             carJson = Find("DvMod.RemoteDispatch.CarData", "GetAllCarDataJson");
             playerJson = Find("DvMod.RemoteDispatch.PlayerData", "GetPlayerDataJson");
 
+            diagnosis = $"found [{string.Join(", ", found.ToArray())}]"
+                + (missing.Count > 0 ? $", missing [{string.Join(", ", missing.ToArray())}]" : ", nothing missing");
+
             if (trackJson == null && binder.Assembly != null)
             {
-                binder.Fail("RailTracks.GetTrackPointJSON was not found; this version of the mod is not one this panel knows.");
+                binder.Fail($"the track layout could not be read from Remote Dispatch: {diagnosis}.");
+            }
+
+            MethodInfo? Find(string typeName, string method)
+            {
+                Type? owner = binder.Type(typeName);
+                MethodInfo? info = binder.Method(owner, method);
+
+                // Which half failed matters: a missing type means the mod was rearranged, a missing method
+                // on a type that is there means only that one call was renamed
+                (info != null ? found : missing).Add(owner == null ? $"{typeName} (no such type)" : $"{typeName}.{method}");
+                return info;
             }
         }
-
-        private MethodInfo? Find(string typeName, string method) => binder.Method(binder.Type(typeName), method);
     }
 }

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Newtonsoft.Json.Linq;
+using TwitchChat.Api;
+using UnityEngine;
+
+namespace TwitchChat.Plugins.Bundled.Dispatch
+{
+    /// <summary>One length of track, as a run of points in the mod's map coordinates.</summary>
+    internal sealed class TrackLine
+    {
+        internal TrackLine(string id, Vector2[] points)
+        {
+            Id = id;
+            Points = points;
+
+            // The mod's own map draws yard tracks differently from mainline, and tells them apart by
+            // whether the id carries a '#'. Worth keeping: a yard drawn in the same weight as the main
+            // line is an unreadable smudge at map scale
+            IsSiding = !id.Contains("#");
+        }
+
+        internal string Id { get; }
+        internal Vector2[] Points { get; }
+        internal bool IsSiding { get; }
+    }
+
+    /// <summary>A junction, where it is and which way it is set.</summary>
+    internal struct JunctionPoint
+    {
+        internal Vector2 Position;
+        internal int SelectedBranch;
+    }
+
+    /// <summary>Something on the map that moves: a car, a locomotive or a player.</summary>
+    internal struct MapMarker
+    {
+        internal Vector2 Position;
+        internal float Rotation;
+        internal bool IsPlayer;
+        internal bool IsLoco;
+    }
+
+    /// <summary>
+    /// Reads mspielberg's Remote Dispatch mod: the track layout, the junctions, and where everything is.
+    /// </summary>
+    /// <remarks>
+    /// That mod renders nothing in the game at all. Its map is a Leaflet page served over HTTP to a
+    /// browser, which is no use in a headset. What it does have is a data layer that is entirely public
+    /// statics and quite separate from the HTTP layer, so the same figures its web page draws can be had
+    /// in process - no port, no password, no dependency on the player having the server switched on.
+    /// <para>
+    /// The methods used here return the JSON its own endpoints return, so the shapes below are the shapes
+    /// its own map already consumes: a public contract rather than an internal detail. Coordinates are
+    /// the mod's own flat latitude and longitude, metres divided by the earth's circumference, which is
+    /// only a projection convention and needs no undoing here.
+    /// </para>
+    /// </remarks>
+    internal sealed class DispatchBridge
+    {
+        internal const string ModId = "RemoteDispatch";
+
+        private readonly ModBinder binder = new(ModId);
+
+        private MethodInfo? trackJson;
+        private MethodInfo? junctionJson;
+        private MethodInfo? junctionStateJson;
+        private MethodInfo? carJson;
+        private MethodInfo? playerJson;
+        private bool lookedUp;
+
+        internal bool IsInstalled => binder.IsModPresent;
+
+        internal string? Error => binder.Error;
+
+        /// <summary>
+        /// The whole track layout. Large, and it does not change during a session, so read it once.
+        /// </summary>
+        internal List<TrackLine> Tracks()
+        {
+            Bind();
+            List<TrackLine> tracks = new();
+
+            if (Read(trackJson) is not { } json)
+            {
+                return tracks;
+            }
+
+            // { "trackId": [[lat, lon], ...], ... }
+            foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(json))
+            {
+                Vector2[] points = PointList(entry.Value);
+                if (points.Length > 1)
+                {
+                    tracks.Add(new TrackLine(entry.Key, points));
+                }
+            }
+
+            return tracks;
+        }
+
+        /// <summary>Junction positions, which are fixed for the session.</summary>
+        internal List<Vector2> JunctionPositions()
+        {
+            Bind();
+            List<Vector2> positions = new();
+
+            if (Read(junctionJson) is not { } json)
+            {
+                return positions;
+            }
+
+            // [ { "position": [lat, lon], "branches": [trackId, trackId] }, ... ]
+            foreach (JToken entry in JArray.Parse(json))
+            {
+                if (Point(entry["position"]) is { } position)
+                {
+                    positions.Add(position);
+                }
+            }
+
+            return positions;
+        }
+
+        /// <summary>
+        /// Which way each junction is set, in the same order as the positions. Changes as switches are
+        /// thrown, so unlike the positions this is worth re-reading.
+        /// </summary>
+        internal int[] JunctionStates()
+        {
+            Bind();
+
+            if (Read(junctionStateJson) is not { } json)
+            {
+                return Array.Empty<int>();
+            }
+
+            // [ selectedBranch, ... ], one per junction, in the same order as the positions
+            return JArray.Parse(json).Select(state => state.Type == JTokenType.Integer ? (int)state : -1).ToArray();
+        }
+
+        /// <summary>Every car the mod is willing to report, plus every player.</summary>
+        internal List<MapMarker> Markers()
+        {
+            Bind();
+            List<MapMarker> markers = new();
+
+            if (Read(carJson) is { } cars)
+            {
+                // { "carId": { "position": [lat, lon], "rotation": deg, ... }, ... }
+                foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(cars))
+                {
+                    if (Marker(entry.Value, isPlayer: false) is { } marker)
+                    {
+                        // Locomotive ids start with L-, and picking them out is what makes the map
+                        // readable: a train is a lot of dots and only one of them is being driven
+                        marker.IsLoco = entry.Key.StartsWith("L-", StringComparison.Ordinal);
+                        markers.Add(marker);
+                    }
+                }
+            }
+
+            if (Read(playerJson) is { } players)
+            {
+                // { "playerId": { "color": name, "position": [lat, lon], "rotation": deg }, ... }
+                foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(players))
+                {
+                    if (Marker(entry.Value, isPlayer: true) is { } marker)
+                    {
+                        markers.Add(marker);
+                    }
+                }
+            }
+
+            return markers;
+        }
+
+        // ------------------------------------------------------------------
+
+        private static MapMarker? Marker(JToken? token, bool isPlayer)
+        {
+            if (token == null || Point(token["position"]) is not { } position)
+            {
+                return null;
+            }
+
+            JToken? rotation = token["rotation"];
+
+            return new MapMarker
+            {
+                Position = position,
+                Rotation = rotation == null || rotation.Type == JTokenType.Null ? 0f : (float)rotation,
+                IsPlayer = isPlayer
+            };
+        }
+
+        private static Vector2? Point(JToken? token)
+        {
+            return token is JArray pair && pair.Count >= 2
+                ? new Vector2((float)pair[0], (float)pair[1])
+                : null;
+        }
+
+        private static Vector2[] PointList(JToken? token)
+        {
+            if (token is not JArray points)
+            {
+                return Array.Empty<Vector2>();
+            }
+
+            List<Vector2> result = new(points.Count);
+            foreach (JToken point in points)
+            {
+                if (Point(point) is { } parsed)
+                {
+                    result.Add(parsed);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Calls one of the mod's JSON methods and returns what it produced, or null.
+        /// </summary>
+        /// <remarks>
+        /// Some of these are iterators that yield the document in pieces rather than returning it whole,
+        /// which is sensible when the other end is a socket and irrelevant here, so both shapes are
+        /// accepted and joined.
+        /// </remarks>
+        private string? Read(MethodInfo? method)
+        {
+            object? result = binder.Invoke(method, null, Arguments(method));
+
+            switch (result)
+            {
+                case null:
+                    return null;
+                case string json:
+                    return json;
+                case IEnumerable pieces:
+                    StringBuilder joined = new();
+                    foreach (object? piece in pieces)
+                    {
+                        joined.Append(piece);
+                    }
+                    return joined.ToString();
+                default:
+                    return result.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Fills in a method's optional parameters, so a version that takes, say, a resolution still
+        /// answers rather than failing on the argument count.
+        /// </summary>
+        private static object?[] Arguments(MethodInfo? method)
+        {
+            ParameterInfo[] parameters = method?.GetParameters() ?? Array.Empty<ParameterInfo>();
+            return parameters.Length == 0
+                ? Array.Empty<object?>()
+                : parameters.Select(p => p.HasDefaultValue ? p.DefaultValue : DefaultOf(p.ParameterType)).ToArray();
+        }
+
+        private static object? DefaultOf(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
+
+        private void Bind()
+        {
+            if (lookedUp)
+            {
+                return;
+            }
+
+            lookedUp = true;
+
+            trackJson = Find("DvMod.RemoteDispatch.RailTracks", "GetTrackPointJSON");
+            junctionJson = Find("DvMod.RemoteDispatch.Junctions", "GetJunctionPointJSON");
+            junctionStateJson = Find("DvMod.RemoteDispatch.Junctions", "GetJunctionStateJSON");
+            carJson = Find("DvMod.RemoteDispatch.CarData", "GetAllCarDataJson");
+            playerJson = Find("DvMod.RemoteDispatch.PlayerData", "GetPlayerDataJson");
+
+            if (trackJson == null && binder.Assembly != null)
+            {
+                binder.Fail("RailTracks.GetTrackPointJSON was not found; this version of the mod is not one this panel knows.");
+            }
+        }
+
+        private MethodInfo? Find(string typeName, string method) => binder.Method(binder.Type(typeName), method);
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchBridge.cs
@@ -44,19 +44,39 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         internal bool IsLoco;
     }
 
+    /// <summary>The parts of the map that do not change during a session.</summary>
+    internal sealed class DispatchLayout
+    {
+        internal List<TrackLine> Tracks = new();
+        internal List<Vector2> Junctions = new();
+    }
+
+    /// <summary>The parts that do.</summary>
+    internal sealed class DispatchLive
+    {
+        internal List<MapMarker> Markers = new();
+        internal int[] JunctionStates = Array.Empty<int>();
+    }
+
     /// <summary>
     /// Reads mspielberg's Remote Dispatch mod: the track layout, the junctions, and where everything is.
     /// </summary>
     /// <remarks>
     /// That mod renders nothing in the game at all. Its map is a Leaflet page served over HTTP to a
-    /// browser, which is no use in a headset. What it does have is a data layer that is entirely public
-    /// statics and quite separate from the HTTP layer, so the same figures its web page draws can be had
-    /// in process - no port, no password, no dependency on the player having the server switched on.
+    /// browser, which is no use in a headset. It does have a data layer of public statics, quite separate
+    /// from the HTTP layer, which is what this reads.
     /// <para>
-    /// The methods used here return what its own endpoints return, so the shapes below are the shapes its
-    /// own map already consumes: a public contract rather than an internal detail. Coordinates are the
-    /// mod's own flat latitude and longitude, metres divided by the earth's circumference, which is only
-    /// a projection convention and needs no undoing here.
+    /// <b>Every one of those calls is made from a background thread, and none from the game loop.</b>
+    /// They look synchronous and are not: they hand their work to that mod's own main-thread pump and
+    /// wait for the answer, because the callers they were written for are HTTP worker threads. Called
+    /// from the main thread, such a method waits for the main thread to do something the main thread
+    /// cannot do while waiting, and the game stops dead with no exception and nothing in any log. That is
+    /// not a fault in either mod; it is what those methods are for, used wrongly.
+    /// </para>
+    /// <para>
+    /// So requests are started on a worker and collected a frame or two later. The shapes below are the
+    /// ones its own map already consumes, and coordinates are its own flat latitude and longitude, metres
+    /// divided by the earth's circumference, which is only a projection convention.
     /// </para>
     /// </remarks>
     internal sealed class DispatchBridge
@@ -72,14 +92,15 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         private MethodInfo? playerJson;
         private bool lookedUp;
 
-        /// <summary>The track layout request, once made. See <see cref="TryReadTracks"/>.</summary>
-        private Task<string>? trackRequest;
+        private BackgroundRead<DispatchLayout>? layoutRead;
+        private BackgroundRead<DispatchLive>? liveRead;
 
         private string diagnosis = "not looked up yet";
 
         internal bool IsInstalled => binder.IsModPresent;
 
-        internal string? Error => binder.Error;
+        /// <summary>Whatever last went wrong, in a sentence, or null.</summary>
+        internal string? Error { get; private set; }
 
         /// <summary>
         /// What was and was not found when binding, for the log. Reading another mod by name is the part
@@ -96,125 +117,96 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         }
 
         /// <summary>
-        /// The whole track layout, which is large and does not change during a session.
+        /// The track and junction layout. Asks for it the first time, and returns null on every call
+        /// until the answer arrives.
         /// </summary>
-        /// <remarks>
-        /// This one is asynchronous on the other side: it hands the work to that mod's own main-thread
-        /// pump, because its usual caller is an HTTP worker thread. We are already on the main thread, so
-        /// waiting on the result here would stop the very loop that has to run for it to be produced, and
-        /// hang the game. Hence a request left in flight and picked up on a later frame.
-        /// </remarks>
-        /// <returns>Null while the answer is still coming, otherwise the tracks - empty if it failed.</returns>
-        internal List<TrackLine>? TryReadTracks()
+        internal DispatchLayout? PollLayout()
         {
             Bind();
 
             if (trackJson == null)
             {
-                return new List<TrackLine>();
+                return new DispatchLayout();
             }
 
-            if (trackRequest == null)
-            {
-                object? result = binder.Invoke(trackJson, null, Arguments(trackJson));
+            return Poll(ref layoutRead, ReadLayout);
+        }
 
-                switch (result)
-                {
-                    case null:
-                        return new List<TrackLine>();
+        /// <summary>
+        /// Where everything is now. Asks again each time the previous answer has been collected, so there
+        /// is never more than one request in flight.
+        /// </summary>
+        internal DispatchLive? PollLive()
+        {
+            Bind();
+            return Poll(ref liveRead, ReadLive);
+        }
 
-                    // Older builds answered directly; take that at once rather than making a frame of it
-                    case string immediate:
-                        return ParseTracks(immediate);
+        private T? Poll<T>(ref BackgroundRead<T>? slot, Func<T> work) where T : class
+        {
+            slot ??= new BackgroundRead<T>(work);
 
-                    case Task<string> pending:
-                        trackRequest = pending;
-                        break;
-
-                    default:
-                        binder.Fail($"RailTracks.GetTrackPointJSON returned {result.GetType().Name}, which this panel does not know how to read.");
-                        return new List<TrackLine>();
-                }
-            }
-
-            if (!trackRequest.IsCompleted)
+            if (!slot.Done)
             {
                 return null;
             }
 
-            Task<string> finished = trackRequest;
-            trackRequest = null;
+            BackgroundRead<T> finished = slot;
+            slot = null;
 
-            if (finished.IsFaulted)
+            if (finished.Failure is { } failure)
             {
-                binder.Fail($"reading the track layout threw: {finished.Exception?.GetBaseException().Message}");
-                return new List<TrackLine>();
+                Error = failure;
+                return null;
             }
 
-            return ParseTracks(finished.Result);
+            return finished.Result;
         }
 
-        private List<TrackLine> ParseTracks(string json)
-        {
-            List<TrackLine> tracks = new();
+        // ------------------------------------------------------------------
+        // Everything below this line runs on a worker thread
+        // ------------------------------------------------------------------
 
-            // { "trackId": [[lat, lon], ...], ... }
-            foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(json))
+        private DispatchLayout ReadLayout()
+        {
+            DispatchLayout layout = new();
+
+            // This one is declared as returning a Task because that mod produces it on its own pump.
+            // Waiting on it here is fine and is the point: this is a worker, and the main thread is free
+            // to run the pump that completes it
+            if (Text(binder.Invoke(trackJson, null, Arguments(trackJson))) is { } trackText)
             {
-                Vector2[] points = PointList(entry.Value);
-                if (points.Length > 1)
+                // { "trackId": [[lat, lon], ...], ... }
+                foreach (KeyValuePair<string, JToken?> entry in JObject.Parse(trackText))
                 {
-                    tracks.Add(new TrackLine(entry.Key, points));
+                    Vector2[] points = PointList(entry.Value);
+                    if (points.Length > 1)
+                    {
+                        layout.Tracks.Add(new TrackLine(entry.Key, points));
+                    }
                 }
-            }
-
-            return tracks;
-        }
-
-        /// <summary>Junction positions, which are fixed for the session.</summary>
-        internal List<Vector2> JunctionPositions()
-        {
-            Bind();
-            List<Vector2> positions = new();
-
-            if (ReadJson(junctionJson) is not JArray entries)
-            {
-                return positions;
             }
 
             // [ { "position": [lat, lon], "branches": [trackId, trackId] }, ... ]
-            foreach (JToken entry in entries)
+            if (Json(junctionJson) is JArray junctions)
             {
-                if (Point(entry["position"]) is { } position)
+                foreach (JToken entry in junctions)
                 {
-                    positions.Add(position);
+                    if (Point(entry["position"]) is { } position)
+                    {
+                        layout.Junctions.Add(position);
+                    }
                 }
             }
 
-            return positions;
+            return layout;
         }
 
-        /// <summary>
-        /// Which way each junction is set, in the same order as the positions. Changes as switches are
-        /// thrown, so unlike the positions this is worth re-reading.
-        /// </summary>
-        internal int[] JunctionStates()
+        private DispatchLive ReadLive()
         {
-            Bind();
+            DispatchLive live = new();
 
-            // [ selectedBranch, ... ], one per junction, in the same order as the positions
-            return ReadJson(junctionStateJson) is not JArray states
-                ? Array.Empty<int>()
-                : states.Select(state => state.Type == JTokenType.Integer ? (int)state : -1).ToArray();
-        }
-
-        /// <summary>Every car the mod is willing to report, plus every player.</summary>
-        internal List<MapMarker> Markers()
-        {
-            Bind();
-            List<MapMarker> markers = new();
-
-            if (ReadJson(carJson) is JObject cars)
+            if (Json(carJson) is JObject cars)
             {
                 // { "carId": { "position": [lat, lon], "rotation": deg, ... }, ... }
                 foreach (KeyValuePair<string, JToken?> entry in cars)
@@ -224,27 +216,59 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                         // Locomotive ids start with L-, and picking them out is what makes the map
                         // readable: a train is a lot of dots and only one of them is being driven
                         marker.IsLoco = entry.Key.StartsWith("L-", StringComparison.Ordinal);
-                        markers.Add(marker);
+                        live.Markers.Add(marker);
                     }
                 }
             }
 
-            if (ReadJson(playerJson) is JObject players)
+            if (Json(playerJson) is JObject players)
             {
                 // { "playerId": { "color": name, "position": [lat, lon], "rotation": deg }, ... }
                 foreach (KeyValuePair<string, JToken?> entry in players)
                 {
                     if (Marker(entry.Value, isPlayer: true) is { } marker)
                     {
-                        markers.Add(marker);
+                        live.Markers.Add(marker);
                     }
                 }
             }
 
-            return markers;
+            // [ selectedBranch, ... ], one per junction, in the same order as the positions
+            if (Json(junctionStateJson) is JArray states)
+            {
+                live.JunctionStates = states
+                    .Select(state => state.Type == JTokenType.Integer ? (int)state : -1)
+                    .ToArray();
+            }
+
+            return live;
         }
 
-        // ------------------------------------------------------------------
+        /// <summary>Calls one of the mod's data methods and reads the answer as JSON.</summary>
+        private JToken? Json(MethodInfo? method)
+        {
+            object? result = binder.Invoke(method, null, Arguments(method));
+
+            return result switch
+            {
+                JToken token => token,
+                _ => Text(result) is { } text ? JToken.Parse(text) : null
+            };
+        }
+
+        /// <summary>
+        /// The text of an answer, waiting for it if the method handed back a promise of one.
+        /// </summary>
+        private static string? Text(object? result)
+        {
+            return result switch
+            {
+                null => null,
+                string text => text,
+                Task<string> pending => pending.GetAwaiter().GetResult(),
+                _ => result.ToString()
+            };
+        }
 
         private static MapMarker? Marker(JToken? token, bool isPlayer)
         {
@@ -290,34 +314,6 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         }
 
         /// <summary>
-        /// Calls one of the mod's synchronous data methods and returns what it produced as JSON.
-        /// </summary>
-        /// <remarks>
-        /// Some of these hand back a parsed document and some the text of one, which is the sort of
-        /// difference that should cost a line here rather than a panel.
-        /// </remarks>
-        private JToken? ReadJson(MethodInfo? method)
-        {
-            object? result = binder.Invoke(method, null, Arguments(method));
-
-            try
-            {
-                return result switch
-                {
-                    null => null,
-                    JToken token => token,
-                    string text => JToken.Parse(text),
-                    _ => null
-                };
-            }
-            catch (Exception ex)
-            {
-                binder.Fail($"the answer from '{method?.Name}' could not be read as JSON: {ex.Message}");
-                return null;
-            }
-        }
-
-        /// <summary>
         /// Fills in a method's parameters, so a version that takes, say, a resolution still answers
         /// rather than failing on the argument count.
         /// </summary>
@@ -354,7 +350,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
             if (trackJson == null && binder.Assembly != null)
             {
-                binder.Fail($"the track layout could not be read from Remote Dispatch: {diagnosis}.");
+                Error = $"the track layout could not be read from Remote Dispatch: {diagnosis}.";
             }
 
             MethodInfo? Find(string typeName, string method)
@@ -367,6 +363,27 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 (info != null ? found : missing).Add(owner == null ? $"{typeName} (no such type)" : $"{typeName}.{method}");
                 return info;
             }
+        }
+
+        /// <summary>
+        /// One reading of another mod, in flight on a worker thread.
+        /// </summary>
+        private sealed class BackgroundRead<T> where T : class
+        {
+            private readonly Task<T> task;
+
+            internal BackgroundRead(Func<T> work)
+            {
+                task = Task.Run(work);
+            }
+
+            internal bool Done => task.IsCompleted;
+
+            internal T? Result => task.Status == TaskStatus.RanToCompletion ? task.Result : null;
+
+            internal string? Failure => task.IsFaulted
+                ? task.Exception?.GetBaseException().Message ?? "the read failed"
+                : task.IsCanceled ? "the read was cancelled" : null;
         }
     }
 }

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
@@ -1,0 +1,333 @@
+using System.Collections.Generic;
+using System.Linq;
+using TwitchChat.Api;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.Plugins.Bundled.Dispatch
+{
+    /// <summary>
+    /// A live map of the railway: the track, the junctions, every train and every player, drawn from the
+    /// Remote Dispatch mod's own data.
+    /// </summary>
+    /// <remarks>
+    /// The mod this reads from shows all of this already, as a Leaflet page in a browser. A browser is
+    /// exactly what a player in a headset has not got, which is the whole reason for this panel. It is an
+    /// overview, not a replacement: there are no job details, no car list and no locomotive control here.
+    /// </remarks>
+    internal sealed class DispatchMapContent : IPanelContent
+    {
+        /// <summary>How often the moving things are re-read. The mod's own page polls faster; a panel a
+        /// person glances at does not need to.</summary>
+        private const float RefreshInterval = 0.5f;
+
+        /// <summary>Room for the two rows of buttons, in canvas units, below the title row.</summary>
+        private const float HeaderHeight = 46f;
+
+        /// <summary>How far the map spans at each end of the zoom range, in the mod's degrees.</summary>
+        private const float WidestSpan = 0.17f;
+        private const float NarrowestSpan = 0.004f;
+
+        private readonly IPanelSurface surface;
+        private readonly DispatchBridge dispatch;
+
+        private List<TrackLine> tracks = new();
+        private List<Vector2> junctionPositions = new();
+        private int[] junctionStates = System.Array.Empty<int>();
+
+        /// <summary>
+        /// Built on first use rather than in the constructor. A panel is created for every display
+        /// whether or not it is the one on show, and the map's textures are the largest thing any panel
+        /// here allocates; a display showing chat should not be paying for them.
+        /// </summary>
+        private MapCanvas? canvas;
+
+        private GameObject? mapArea;
+        private Text? status;
+        private Text? followLabel;
+
+        private bool loaded;
+        private bool announced;
+        private bool follow = true;
+        private bool terrainDirty = true;
+        private float untilRefresh;
+
+        internal DispatchMapContent(IPanelSurface surface, DispatchBridge dispatch)
+        {
+            this.surface = surface;
+            this.dispatch = dispatch;
+
+            surface.ReserveHeader(HeaderHeight);
+            Build();
+        }
+
+        public void OnShow()
+        {
+            terrainDirty = true;
+            Refresh();
+        }
+
+        public void OnHide() { }
+
+        public void OnResize(Vector2 size) { }
+
+        public void Tick(float deltaTime)
+        {
+            untilRefresh -= deltaTime;
+            if (untilRefresh > 0f)
+            {
+                return;
+            }
+
+            untilRefresh = RefreshInterval;
+            Refresh();
+        }
+
+        // ------------------------------------------------------------------
+        // Building
+        // ------------------------------------------------------------------
+
+        private void Build()
+        {
+            // Zoom and follow on the first row, panning on the second
+            surface.Widgets.CreateButton(surface.Root, "-", 24, 44, Color.white, () => Zoom(1f / 0.6f), 28);
+            surface.Widgets.CreateButton(surface.Root, "+", 56, 44, Color.white, () => Zoom(0.6f), 28);
+
+            Button followButton = surface.Widgets.CreateButton(surface.Root, "Follow", 112, 44, Color.white, ToggleFollow, 76);
+            followLabel = followButton.GetComponentInChildren<Text>();
+
+            surface.Widgets.CreateButton(surface.Root, "^", 172, 44, Color.white, () => Pan(1, 0), 26);
+            surface.Widgets.CreateButton(surface.Root, "v", 202, 44, Color.white, () => Pan(-1, 0), 26);
+            surface.Widgets.CreateButton(surface.Root, "<", 172, 66, Color.white, () => Pan(0, -1), 26);
+            surface.Widgets.CreateButton(surface.Root, ">", 202, 66, Color.white, () => Pan(0, 1), 26);
+
+            // The map keeps its square shape whatever shape the display has been dragged into, since the
+            // texture and the coordinates behind it are both square
+            GameObject container = new("MapContainer", typeof(RectTransform));
+            container.transform.SetParent(surface.Root, false);
+
+            RectTransform containerRect = container.GetComponent<RectTransform>();
+            containerRect.anchorMin = Vector2.zero;
+            containerRect.anchorMax = Vector2.one;
+            containerRect.offsetMin = new Vector2(6, 6);
+            containerRect.offsetMax = new Vector2(-6, -(35f + HeaderHeight + 24f));
+
+            mapArea = new GameObject("Map", typeof(RectTransform));
+            mapArea.transform.SetParent(container.transform, false);
+
+            RectTransform mapRect = mapArea.GetComponent<RectTransform>();
+            mapRect.anchorMin = new Vector2(0.5f, 0.5f);
+            mapRect.anchorMax = new Vector2(0.5f, 0.5f);
+            mapRect.pivot = new Vector2(0.5f, 0.5f);
+
+            AspectRatioFitter fitter = mapArea.AddComponent<AspectRatioFitter>();
+            fitter.aspectMode = AspectRatioFitter.AspectMode.FitInParent;
+            fitter.aspectRatio = 1f;
+
+            status = surface.Widgets.CreateText(surface.Root, "Reading the track layout...", 10, 88, Color.gray, lines: 2);
+
+            UpdateFollowLabel();
+        }
+
+        /// <summary>
+        /// Makes the drawing surface, the first time the panel is actually asked to draw one.
+        /// </summary>
+        private MapCanvas EnsureCanvas()
+        {
+            if (canvas != null)
+            {
+                return canvas;
+            }
+
+            canvas = new MapCanvas();
+
+            if (mapArea != null)
+            {
+                AddLayer(mapArea.transform, canvas.Terrain);
+                AddLayer(mapArea.transform, canvas.Markers);
+
+                // Textures outlive their references unless something destroys them, and the panel's own
+                // object is the right thing to tie them to
+                mapArea.AddComponent<MapTextureOwner>().Own(canvas);
+            }
+
+            return canvas;
+        }
+
+        private static void AddLayer(Transform parent, Texture2D texture)
+        {
+            GameObject layer = new(texture.name, typeof(RectTransform));
+            layer.transform.SetParent(parent, false);
+
+            RawImage image = layer.AddComponent<RawImage>();
+            image.texture = texture;
+            image.raycastTarget = false;
+
+            RectTransform rect = layer.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        // ------------------------------------------------------------------
+        // Controls
+        // ------------------------------------------------------------------
+
+        private void Zoom(float factor)
+        {
+            MapCanvas map = EnsureCanvas();
+            map.Span = Mathf.Clamp(map.Span * factor, NarrowestSpan, WidestSpan);
+            terrainDirty = true;
+        }
+
+        private void Pan(int latSteps, int lonSteps)
+        {
+            // Panning by hand means the player wants to look somewhere other than at themselves
+            follow = false;
+            UpdateFollowLabel();
+
+            MapCanvas map = EnsureCanvas();
+            float step = map.Span * 0.25f;
+            map.Centre += new Vector2(latSteps * step, lonSteps * step);
+            terrainDirty = true;
+        }
+
+        private void ToggleFollow()
+        {
+            follow = !follow;
+            UpdateFollowLabel();
+        }
+
+        private void UpdateFollowLabel()
+        {
+            if (followLabel != null)
+            {
+                followLabel.text = follow ? "Following" : "Follow";
+                followLabel.color = follow ? Color.cyan : Color.white;
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Drawing
+        // ------------------------------------------------------------------
+
+        private void Refresh()
+        {
+            if (!dispatch.IsInstalled)
+            {
+                Say("The Remote Dispatch mod is not installed.");
+                return;
+            }
+
+            if (!loaded && !LoadLayout())
+            {
+                return;
+            }
+
+            MapCanvas map = EnsureCanvas();
+            List<MapMarker> markers = dispatch.Markers();
+
+            if (follow && markers.FirstOrDefault(marker => marker.IsPlayer) is { IsPlayer: true } player)
+            {
+                // Recentre only once the player has drifted well away from the middle, so that walking
+                // about does not redraw every rail on the map twice a second
+                if ((player.Position - map.Centre).sqrMagnitude > Mathf.Pow(map.Span * 0.2f, 2f))
+                {
+                    map.Centre = player.Position;
+                    terrainDirty = true;
+                }
+            }
+
+            // A switch thrown anywhere on the map changes the terrain layer, and a dispatcher watching
+            // this panel is precisely the person who wants to see that happen
+            int[] states = dispatch.JunctionStates();
+            if (!states.SequenceEqual(junctionStates))
+            {
+                junctionStates = states;
+                terrainDirty = true;
+            }
+
+            if (terrainDirty)
+            {
+                terrainDirty = false;
+                map.DrawTerrain(tracks, Junctions());
+            }
+
+            map.DrawMarkers(markers);
+
+            int trains = markers.Count(marker => marker.IsLoco);
+            Say($"{tracks.Count} tracks, {markers.Count(m => !m.IsPlayer)} cars, {trains} locos.  {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}% of the map");
+        }
+
+        /// <summary>The junctions, paired with which way each is currently set.</summary>
+        private IEnumerable<JunctionPoint> Junctions()
+        {
+            for (int i = 0; i < junctionPositions.Count; i++)
+            {
+                yield return new JunctionPoint
+                {
+                    Position = junctionPositions[i],
+                    SelectedBranch = i < junctionStates.Length ? junctionStates[i] : -1
+                };
+            }
+        }
+
+        /// <summary>
+        /// Reads the track layout, which is the expensive part and does not change during a session.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not done on the first tick: the panel says what it is doing, and only reads on the
+        /// tick after that, so the message is on screen before the game stops to parse the whole railway.
+        /// </remarks>
+        private bool LoadLayout()
+        {
+            if (!announced)
+            {
+                announced = true;
+                Say("Reading the track layout...");
+                return false;
+            }
+
+            tracks = dispatch.Tracks();
+
+            if (tracks.Count == 0)
+            {
+                Say(dispatch.Error ?? "No track layout yet. It appears once a save is loaded.");
+
+                // Not a permanent failure: the world may simply not be loaded, so try again next refresh
+                announced = false;
+                return false;
+            }
+
+            junctionPositions = dispatch.JunctionPositions();
+            loaded = true;
+
+            // Start looking at the whole railway, centred on it
+            Bounds bounds = new(tracks[0].Points[0], Vector3.zero);
+            foreach (TrackLine track in tracks)
+            {
+                foreach (Vector2 point in track.Points)
+                {
+                    bounds.Encapsulate(point);
+                }
+            }
+
+            MapCanvas map = EnsureCanvas();
+            map.Centre = bounds.center;
+            map.Span = Mathf.Clamp(Mathf.Max(bounds.size.x, bounds.size.y) * 1.05f, NarrowestSpan, WidestSpan);
+            terrainDirty = true;
+
+            surface.Log($"Read {tracks.Count} tracks and {junctionPositions.Count} junctions from Remote Dispatch.");
+            return true;
+        }
+
+        private void Say(string message)
+        {
+            if (status != null)
+            {
+                status.text = message;
+            }
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
@@ -24,6 +24,9 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         /// <summary>Room for the two rows of buttons, in canvas units, below the title row.</summary>
         private const float HeaderHeight = 46f;
 
+        /// <summary>Room for the one line of status under the buttons, above the map.</summary>
+        private const float StatusHeight = 22f;
+
         /// <summary>How far the map spans at each end of the zoom range, in the mod's degrees.</summary>
         private const float WidestSpan = 0.17f;
         private const float NarrowestSpan = 0.004f;
@@ -110,7 +113,9 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             containerRect.anchorMin = Vector2.zero;
             containerRect.anchorMax = Vector2.one;
             containerRect.offsetMin = new Vector2(6, 6);
-            containerRect.offsetMax = new Vector2(-6, -(35f + HeaderHeight + 24f));
+
+            // Below the title row, the two rows of buttons, and the status line under them
+            containerRect.offsetMax = new Vector2(-6, -(35f + HeaderHeight + StatusHeight));
 
             mapArea = new GameObject("Map", typeof(RectTransform));
             mapArea.transform.SetParent(container.transform, false);
@@ -124,7 +129,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             fitter.aspectMode = AspectRatioFitter.AspectMode.FitInParent;
             fitter.aspectRatio = 1f;
 
-            status = surface.Widgets.CreateText(surface.Root, "Reading the track layout...", 10, 88, Color.gray, lines: 2);
+            status = surface.Widgets.CreateText(surface.Root, "Reading the track layout...", 10, 35 + (int)HeaderHeight + 4, Color.gray);
 
             UpdateFollowLabel();
         }
@@ -257,7 +262,8 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             map.DrawMarkers(markers);
 
             int trains = markers.Count(marker => marker.IsLoco);
-            Say($"{tracks.Count} tracks, {markers.Count(m => !m.IsPlayer)} cars, {trains} locos.  {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}% of the map");
+            // One short line: the panel can be dragged narrow, and a status that wraps eats the map
+            Say($"{markers.Count(m => !m.IsPlayer)} cars, {trains} locos, {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}%");
         }
 
         /// <summary>The junctions, paired with which way each is currently set.</summary>

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
@@ -51,6 +51,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
         private bool loaded;
         private bool announced;
+        private bool loggedDiagnosis;
         private bool follow = true;
         private bool terrainDirty = true;
         private float untilRefresh;
@@ -283,8 +284,9 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         /// Reads the track layout, which is the expensive part and does not change during a session.
         /// </summary>
         /// <remarks>
-        /// Deliberately not done on the first tick: the panel says what it is doing, and only reads on the
-        /// tick after that, so the message is on screen before the game stops to parse the whole railway.
+        /// The answer does not come back on the frame it is asked for: the other mod produces it on its
+        /// own main-thread pump, so it arrives a frame or two later and this is called again until it
+        /// does. Waiting for it here instead would stop the loop that has to run to produce it.
         /// </remarks>
         private bool LoadLayout()
         {
@@ -292,16 +294,32 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             {
                 announced = true;
                 Say("Reading the track layout...");
+
+                // Written once per panel, before the read that may fail, so a report of the failure comes
+                // with the record of what this panel managed to find in the other mod. Once only: this is
+                // retried until a save is loaded, and a line a second would bury everything else
+                if (!loggedDiagnosis)
+                {
+                    loggedDiagnosis = true;
+                    surface.Log($"Binding to Remote Dispatch: {dispatch.Diagnosis}");
+                }
+            }
+
+            List<TrackLine>? read = dispatch.TryReadTracks();
+
+            if (read == null)
+            {
+                // Still coming. Say nothing new; the message from a moment ago still stands
                 return false;
             }
 
-            tracks = dispatch.Tracks();
+            tracks = read;
 
             if (tracks.Count == 0)
             {
                 Say(dispatch.Error ?? "No track layout yet. It appears once a save is loaded.");
 
-                // Not a permanent failure: the world may simply not be loaded, so try again next refresh
+                // Not a permanent failure: the world may simply not be loaded, so ask again next refresh
                 announced = false;
                 return false;
             }

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
@@ -27,6 +27,13 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         /// <summary>Room for the one line of status under the buttons, above the map.</summary>
         private const float StatusHeight = 22f;
 
+        /// <summary>
+        /// How many track segments are drawn per frame. Enough that the map appears at once on a normal
+        /// railway, small enough that an unusually large one costs several quiet frames rather than one
+        /// very long stall.
+        /// </summary>
+        private const int SegmentsPerFrame = 8000;
+
         /// <summary>How far the map spans at each end of the zoom range, in the mod's degrees.</summary>
         private const float WidestSpan = 0.17f;
         private const float NarrowestSpan = 0.004f;
@@ -52,6 +59,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         private bool loaded;
         private bool announced;
         private bool loggedDiagnosis;
+        private bool traced;
         private bool follow = true;
         private bool terrainDirty = true;
         private float untilRefresh;
@@ -77,6 +85,18 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
         public void Tick(float deltaTime)
         {
+            // A track layer part way through is finished off first, a bounded piece per frame, so the
+            // map builds up over a few frames instead of stopping the game for however long it takes
+            if (canvas != null && canvas.TerrainInProgress)
+            {
+                if (canvas.ContinueTerrain(SegmentsPerFrame))
+                {
+                    surface.Log($"Track layer drawn: {canvas.SegmentsDrawn} segments.");
+                }
+
+                return;
+            }
+
             untilRefresh -= deltaTime;
             if (untilRefresh > 0f)
             {
@@ -125,10 +145,6 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             mapRect.anchorMin = new Vector2(0.5f, 0.5f);
             mapRect.anchorMax = new Vector2(0.5f, 0.5f);
             mapRect.pivot = new Vector2(0.5f, 0.5f);
-
-            AspectRatioFitter fitter = mapArea.AddComponent<AspectRatioFitter>();
-            fitter.aspectMode = AspectRatioFitter.AspectMode.FitInParent;
-            fitter.aspectRatio = 1f;
 
             status = surface.Widgets.CreateText(surface.Root, "Reading the track layout...", 10, 35 + (int)HeaderHeight + 4, Color.gray);
 
@@ -231,7 +247,13 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 return;
             }
 
+            Trace("laying out the map area");
+            LayOutMap();
+
+            Trace("making the drawing surface");
             MapCanvas map = EnsureCanvas();
+
+            Trace("reading cars and players");
             List<MapMarker> markers = dispatch.Markers();
 
             if (follow && markers.FirstOrDefault(marker => marker.IsPlayer) is { IsPlayer: true } player)
@@ -247,6 +269,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
             // A switch thrown anywhere on the map changes the terrain layer, and a dispatcher watching
             // this panel is precisely the person who wants to see that happen
+            Trace("reading junction states");
             int[] states = dispatch.JunctionStates();
             if (!states.SequenceEqual(junctionStates))
             {
@@ -257,26 +280,79 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             if (terrainDirty)
             {
                 terrainDirty = false;
-                map.DrawTerrain(tracks, Junctions());
+                Trace("starting the track layer");
+                map.BeginTerrain(tracks, Junctions());
             }
 
+            Trace("drawing cars and players");
             map.DrawMarkers(markers);
 
             int trains = markers.Count(marker => marker.IsLoco);
             // One short line: the panel can be dragged narrow, and a status that wraps eats the map
             Say($"{markers.Count(m => !m.IsPlayer)} cars, {trains} locos, {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}%");
+
+            Trace("first refresh done");
+            traced = true;
         }
 
         /// <summary>The junctions, paired with which way each is currently set.</summary>
-        private IEnumerable<JunctionPoint> Junctions()
+        private List<JunctionPoint> Junctions()
         {
+            List<JunctionPoint> junctions = new(junctionPositions.Count);
+
             for (int i = 0; i < junctionPositions.Count; i++)
             {
-                yield return new JunctionPoint
+                junctions.Add(new JunctionPoint
                 {
                     Position = junctionPositions[i],
                     SelectedBranch = i < junctionStates.Length ? junctionStates[i] : -1
-                };
+                });
+            }
+
+            return junctions;
+        }
+
+        /// <summary>
+        /// Keeps the map square within whatever room the panel has, whatever shape the display has been
+        /// dragged into.
+        /// </summary>
+        /// <remarks>
+        /// Six lines of arithmetic in place of an AspectRatioFitter. The component does the same job, but
+        /// it does it by driving its own rect from inside the layout pass, and a component that resizes
+        /// itself in response to being resized is the wrong thing to have on a panel that is posed afresh
+        /// every frame and can be dragged to any size by hand.
+        /// </remarks>
+        private void LayOutMap()
+        {
+            if (mapArea == null || mapArea.transform.parent == null)
+            {
+                return;
+            }
+
+            RectTransform container = (RectTransform)mapArea.transform.parent;
+            RectTransform map = (RectTransform)mapArea.transform;
+
+            float side = Mathf.Max(0f, Mathf.Min(container.rect.width, container.rect.height));
+            if (!Mathf.Approximately(side, map.sizeDelta.x))
+            {
+                map.sizeDelta = new Vector2(side, side);
+            }
+        }
+
+        /// <summary>
+        /// Writes down each step of the very first refresh, and then stops.
+        /// </summary>
+        /// <remarks>
+        /// This panel does more, and more unusual, work than the others: it reads another mod, allocates
+        /// textures and rasterises into them. When that went wrong the game stopped dead with nothing in
+        /// any log, which left no way to tell which step had done it. One pass of breadcrumbs costs a
+        /// dozen lines once and means the last line written names the step that did not finish.
+        /// </remarks>
+        private void Trace(string step)
+        {
+            if (!traced)
+            {
+                surface.Log($"First refresh: {step}");
             }
         }
 

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapContent.cs
@@ -60,6 +60,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         private bool announced;
         private bool loggedDiagnosis;
         private bool traced;
+        private readonly HashSet<string> tracedSteps = new();
         private bool follow = true;
         private bool terrainDirty = true;
         private float untilRefresh;
@@ -247,16 +248,28 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 return;
             }
 
+            Trace("collecting cars and players");
+            DispatchLive? live = dispatch.PollLive();
+
+            if (live == null)
+            {
+                // The reading is still out with the worker. Everything on screen is a moment old rather
+                // than wrong, so leave it be and look again next time
+                if (dispatch.Error is { } problem)
+                {
+                    Say(problem);
+                }
+
+                return;
+            }
+
             Trace("laying out the map area");
             LayOutMap();
 
             Trace("making the drawing surface");
             MapCanvas map = EnsureCanvas();
 
-            Trace("reading cars and players");
-            List<MapMarker> markers = dispatch.Markers();
-
-            if (follow && markers.FirstOrDefault(marker => marker.IsPlayer) is { IsPlayer: true } player)
+            if (follow && live.Markers.FirstOrDefault(marker => marker.IsPlayer) is { IsPlayer: true } player)
             {
                 // Recentre only once the player has drifted well away from the middle, so that walking
                 // about does not redraw every rail on the map twice a second
@@ -269,11 +282,9 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
             // A switch thrown anywhere on the map changes the terrain layer, and a dispatcher watching
             // this panel is precisely the person who wants to see that happen
-            Trace("reading junction states");
-            int[] states = dispatch.JunctionStates();
-            if (!states.SequenceEqual(junctionStates))
+            if (!live.JunctionStates.SequenceEqual(junctionStates))
             {
-                junctionStates = states;
+                junctionStates = live.JunctionStates;
                 terrainDirty = true;
             }
 
@@ -285,11 +296,11 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             }
 
             Trace("drawing cars and players");
-            map.DrawMarkers(markers);
+            map.DrawMarkers(live.Markers);
 
-            int trains = markers.Count(marker => marker.IsLoco);
+            int trains = live.Markers.Count(marker => marker.IsLoco);
             // One short line: the panel can be dragged narrow, and a status that wraps eats the map
-            Say($"{markers.Count(m => !m.IsPlayer)} cars, {trains} locos, {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}%");
+            Say($"{live.Markers.Count(m => !m.IsPlayer)} cars, {trains} locos, {Mathf.RoundToInt(map.Span / WidestSpan * 100f)}%");
 
             Trace("first refresh done");
             traced = true;
@@ -350,7 +361,10 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         /// </remarks>
         private void Trace(string step)
         {
-            if (!traced)
+            // Each step once, not once per refresh: the early steps run again on every cycle while the
+            // first reading is still out with the worker, and a breadcrumb trail that repeats is no
+            // longer a trail
+            if (!traced && tracedSteps.Add(step))
             {
                 surface.Log($"First refresh: {step}");
             }
@@ -360,9 +374,8 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         /// Reads the track layout, which is the expensive part and does not change during a session.
         /// </summary>
         /// <remarks>
-        /// The answer does not come back on the frame it is asked for: the other mod produces it on its
-        /// own main-thread pump, so it arrives a frame or two later and this is called again until it
-        /// does. Waiting for it here instead would stop the loop that has to run to produce it.
+        /// The answer does not come back on the frame it is asked for. It is read on a worker thread,
+        /// which is the only safe place to read that mod from, and collected here a frame or two later.
         /// </remarks>
         private bool LoadLayout()
         {
@@ -381,7 +394,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 }
             }
 
-            List<TrackLine>? read = dispatch.TryReadTracks();
+            DispatchLayout? read = dispatch.PollLayout();
 
             if (read == null)
             {
@@ -389,7 +402,8 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 return false;
             }
 
-            tracks = read;
+            tracks = read.Tracks;
+            junctionPositions = read.Junctions;
 
             if (tracks.Count == 0)
             {
@@ -400,7 +414,6 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 return false;
             }
 
-            junctionPositions = dispatch.JunctionPositions();
             loaded = true;
 
             // Start looking at the whole railway, centred on it

--- a/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapPlugin.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/DispatchMapPlugin.cs
@@ -1,0 +1,20 @@
+using TwitchChat.Api;
+
+namespace TwitchChat.Plugins.Bundled.Dispatch
+{
+    /// <summary>
+    /// Puts a live map of the railway on a display, drawn from the Remote Dispatch mod's own data.
+    /// </summary>
+    public sealed class DispatchMapPlugin : ITwitchChatPlugin
+    {
+        private readonly DispatchBridge dispatch = new();
+
+        public string Id => "Dispatch Map";
+
+        public string Title => "Dispatch Map";
+
+        public bool IsAvailable => dispatch.IsInstalled;
+
+        public IPanelContent CreateContent(IPanelSurface surface) => new DispatchMapContent(surface, dispatch);
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Dispatch/MapCanvas.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/MapCanvas.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TwitchChat.Plugins.Bundled.Dispatch
+{
+    /// <summary>
+    /// Draws the map into a pair of textures: a slow one for the track and junctions, which only changes
+    /// when the view does, and a fast one for the things that move, redrawn on every refresh.
+    /// </summary>
+    /// <remarks>
+    /// Two layers rather than one so that a hundred moving cars cost a clear and a hundred dots, not a
+    /// redraw of every rail on the map. Two textures rather than a marker object per car for the same
+    /// reason: creating and destroying that many UI objects several times a second is the expensive way
+    /// to do this, and none of them need to be clickable.
+    /// </remarks>
+    internal sealed class MapCanvas : IDisposable
+    {
+        /// <summary>
+        /// Side of both textures in pixels. The window is redrawn whenever the view moves, so this is
+        /// resolution within the current view rather than over the whole map, and 512 is plenty for a
+        /// panel a person is reading from a couple of feet away.
+        /// </summary>
+        private const int Size = 512;
+
+        private static readonly Color32 Transparent = new(0, 0, 0, 0);
+        private static readonly Color32 Background = new(12, 16, 22, 255);
+        private static readonly Color32 Mainline = new(150, 175, 205, 255);
+        private static readonly Color32 Siding = new(95, 105, 120, 255);
+        private static readonly Color32 JunctionSet = new(90, 200, 255, 255);
+        private static readonly Color32 JunctionUnknown = new(150, 150, 150, 255);
+        private static readonly Color32 Car = new(190, 190, 190, 255);
+        private static readonly Color32 Loco = new(255, 190, 60, 255);
+        private static readonly Color32 Player = new(90, 230, 130, 255);
+
+        private readonly Color32[] terrainPixels = new Color32[Size * Size];
+        private readonly Color32[] markerPixels = new Color32[Size * Size];
+        private readonly Color32[] clearedMarkers = new Color32[Size * Size];
+
+        internal MapCanvas()
+        {
+            Terrain = NewTexture("MapTerrain");
+            Markers = NewTexture("MapMarkers");
+
+            for (int i = 0; i < clearedMarkers.Length; i++)
+            {
+                clearedMarkers[i] = Transparent;
+            }
+        }
+
+        /// <summary>The track and junction layer.</summary>
+        internal Texture2D Terrain { get; }
+
+        /// <summary>The trains and players layer, drawn over the other.</summary>
+        internal Texture2D Markers { get; }
+
+        /// <summary>
+        /// The map coordinates at the centre of the view, and how many degrees of it the view spans.
+        /// </summary>
+        internal Vector2 Centre { get; set; }
+
+        internal float Span { get; set; } = 0.16f;
+
+        /// <summary>Redraws the track and junctions for the current view.</summary>
+        internal void DrawTerrain(IEnumerable<TrackLine> tracks, IEnumerable<JunctionPoint> junctions)
+        {
+            for (int i = 0; i < terrainPixels.Length; i++)
+            {
+                terrainPixels[i] = Background;
+            }
+
+            // Yards first, so a mainline running through one is drawn over it rather than under
+            foreach (TrackLine track in tracks)
+            {
+                Color32 colour = track.IsSiding ? Siding : Mainline;
+
+                for (int i = 1; i < track.Points.Length; i++)
+                {
+                    Line(terrainPixels, ToPixel(track.Points[i - 1]), ToPixel(track.Points[i]), colour);
+                }
+            }
+
+            foreach (JunctionPoint junction in junctions)
+            {
+                Dot(terrainPixels, ToPixel(junction.Position), 1,
+                    junction.SelectedBranch >= 0 ? JunctionSet : JunctionUnknown);
+            }
+
+            Terrain.SetPixels32(terrainPixels);
+            Terrain.Apply(updateMipmaps: false);
+        }
+
+        /// <summary>Redraws the trains and players for the current view.</summary>
+        internal void DrawMarkers(IEnumerable<MapMarker> markers)
+        {
+            Array.Copy(clearedMarkers, markerPixels, markerPixels.Length);
+
+            // Plain cars first, so a locomotive or a player in the middle of a rake stays visible
+            foreach (MapMarker marker in markers)
+            {
+                if (!marker.IsPlayer && !marker.IsLoco)
+                {
+                    Dot(markerPixels, ToPixel(marker.Position), 1, Car);
+                }
+            }
+
+            foreach (MapMarker marker in markers)
+            {
+                if (marker.IsLoco)
+                {
+                    Dot(markerPixels, ToPixel(marker.Position), 2, Loco);
+                }
+            }
+
+            foreach (MapMarker marker in markers)
+            {
+                if (marker.IsPlayer)
+                {
+                    Dot(markerPixels, ToPixel(marker.Position), 3, Player);
+                }
+            }
+
+            Markers.SetPixels32(markerPixels);
+            Markers.Apply(updateMipmaps: false);
+        }
+
+        public void Dispose()
+        {
+            UnityEngine.Object.Destroy(Terrain);
+            UnityEngine.Object.Destroy(Markers);
+        }
+
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Map coordinates to texture pixels. Longitude runs across and latitude up, which is the way
+        /// round the mod's own map has them. A texture counts its rows up from the bottom, which for once
+        /// is what is wanted: north ends up at the top with no flip.
+        /// </summary>
+        private Vector2Int ToPixel(Vector2 point)
+        {
+            float half = Span / 2f;
+            float x = (point.y - (Centre.y - half)) / Span;
+            float y = (point.x - (Centre.x - half)) / Span;
+
+            return new Vector2Int(Mathf.RoundToInt(x * (Size - 1)), Mathf.RoundToInt(y * (Size - 1)));
+        }
+
+        private static Texture2D NewTexture(string name)
+        {
+            return new Texture2D(Size, Size, TextureFormat.RGBA32, mipChain: false)
+            {
+                name = name,
+
+                // Point filtering: a track one pixel wide goes grey and vanishes under bilinear
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp
+            };
+        }
+
+        private static void Dot(Color32[] pixels, Vector2Int at, int radius, Color32 colour)
+        {
+            for (int dy = -radius; dy <= radius; dy++)
+            {
+                for (int dx = -radius; dx <= radius; dx++)
+                {
+                    if (dx * dx + dy * dy <= radius * radius)
+                    {
+                        Plot(pixels, at.x + dx, at.y + dy, colour);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Bresenham, so a line off the edge of the view costs a few comparisons and no memory.</summary>
+        private static void Line(Color32[] pixels, Vector2Int from, Vector2Int to, Color32 colour)
+        {
+            // Both ends far off the same side means the whole segment is: skip it without walking it
+            if ((from.x < 0 && to.x < 0) || (from.y < 0 && to.y < 0) ||
+                (from.x >= Size && to.x >= Size) || (from.y >= Size && to.y >= Size))
+            {
+                return;
+            }
+
+            int dx = Mathf.Abs(to.x - from.x);
+            int dy = -Mathf.Abs(to.y - from.y);
+            int stepX = from.x < to.x ? 1 : -1;
+            int stepY = from.y < to.y ? 1 : -1;
+            int error = dx + dy;
+
+            int x = from.x;
+            int y = from.y;
+
+            // A very long segment out of view could otherwise walk a great many steps for nothing
+            int guard = (dx - dy) + 2;
+
+            while (guard-- > 0)
+            {
+                Plot(pixels, x, y, colour);
+
+                if (x == to.x && y == to.y)
+                {
+                    return;
+                }
+
+                int doubled = error * 2;
+                if (doubled >= dy)
+                {
+                    error += dy;
+                    x += stepX;
+                }
+                if (doubled <= dx)
+                {
+                    error += dx;
+                    y += stepY;
+                }
+            }
+        }
+
+        private static void Plot(Color32[] pixels, int x, int y, Color32 colour)
+        {
+            if (x >= 0 && x < Size && y >= 0 && y < Size)
+            {
+                pixels[(y * Size) + x] = colour;
+            }
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Dispatch/MapCanvas.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/MapCanvas.cs
@@ -13,6 +13,12 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
     /// redraw of every rail on the map. Two textures rather than a marker object per car for the same
     /// reason: creating and destroying that many UI objects several times a second is the expensive way
     /// to do this, and none of them need to be clickable.
+    /// <para>
+    /// The track layer is drawn a bounded number of segments at a time, across frames. Not because the
+    /// railway is known to be too big to draw at once - at forty metres a sample it is not - but because
+    /// how much work "the whole map" is depends on another mod's data and on how far the player has
+    /// zoomed in, and no amount of that belongs in a single frame of a game being played in a headset.
+    /// </para>
     /// </remarks>
     internal sealed class MapCanvas : IDisposable
     {
@@ -36,6 +42,12 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
         private readonly Color32[] terrainPixels = new Color32[Size * Size];
         private readonly Color32[] markerPixels = new Color32[Size * Size];
         private readonly Color32[] clearedMarkers = new Color32[Size * Size];
+
+        // Where the track drawing has got to, since it is spread over several calls
+        private IReadOnlyList<TrackLine>? pendingTracks;
+        private IReadOnlyList<JunctionPoint>? pendingJunctions;
+        private int trackIndex;
+        private int pointIndex;
 
         internal MapCanvas()
         {
@@ -61,33 +73,77 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
         internal float Span { get; set; } = 0.16f;
 
-        /// <summary>Redraws the track and junctions for the current view.</summary>
-        internal void DrawTerrain(IEnumerable<TrackLine> tracks, IEnumerable<JunctionPoint> junctions)
+        /// <summary>How many segments have been drawn since the track layer was last started.</summary>
+        internal int SegmentsDrawn { get; private set; }
+
+        /// <summary>Whether the track layer is part drawn and wants more calls to <see cref="ContinueTerrain"/>.</summary>
+        internal bool TerrainInProgress => pendingTracks != null;
+
+        /// <summary>
+        /// Starts redrawing the track and junction layer. Nothing is drawn yet; call
+        /// <see cref="ContinueTerrain"/> until it reports itself finished.
+        /// </summary>
+        internal void BeginTerrain(IReadOnlyList<TrackLine> tracks, IReadOnlyList<JunctionPoint> junctions)
         {
             for (int i = 0; i < terrainPixels.Length; i++)
             {
                 terrainPixels[i] = Background;
             }
 
-            // Yards first, so a mainline running through one is drawn over it rather than under
-            foreach (TrackLine track in tracks)
-            {
-                Color32 colour = track.IsSiding ? Siding : Mainline;
+            pendingTracks = tracks;
+            pendingJunctions = junctions;
+            trackIndex = 0;
+            pointIndex = 1;
+            SegmentsDrawn = 0;
+        }
 
-                for (int i = 1; i < track.Points.Length; i++)
-                {
-                    Line(terrainPixels, ToPixel(track.Points[i - 1]), ToPixel(track.Points[i]), colour);
-                }
+        /// <summary>
+        /// Draws up to <paramref name="segmentBudget"/> more segments of the track layer.
+        /// </summary>
+        /// <returns>True once the whole layer is drawn.</returns>
+        internal bool ContinueTerrain(int segmentBudget)
+        {
+            if (pendingTracks == null)
+            {
+                return true;
             }
 
-            foreach (JunctionPoint junction in junctions)
+            int drawn = 0;
+
+            while (trackIndex < pendingTracks.Count)
+            {
+                TrackLine track = pendingTracks[trackIndex];
+                Color32 colour = track.IsSiding ? Siding : Mainline;
+
+                while (pointIndex < track.Points.Length)
+                {
+                    Line(terrainPixels, ToPixel(track.Points[pointIndex - 1]), ToPixel(track.Points[pointIndex]), colour);
+                    pointIndex++;
+
+                    if (++drawn >= segmentBudget)
+                    {
+                        SegmentsDrawn += drawn;
+                        Publish(Terrain, terrainPixels);
+                        return false;
+                    }
+                }
+
+                trackIndex++;
+                pointIndex = 1;
+            }
+
+            foreach (JunctionPoint junction in pendingJunctions ?? Array.Empty<JunctionPoint>())
             {
                 Dot(terrainPixels, ToPixel(junction.Position), 1,
                     junction.SelectedBranch >= 0 ? JunctionSet : JunctionUnknown);
             }
 
-            Terrain.SetPixels32(terrainPixels);
-            Terrain.Apply(updateMipmaps: false);
+            SegmentsDrawn += drawn;
+            pendingTracks = null;
+            pendingJunctions = null;
+
+            Publish(Terrain, terrainPixels);
+            return true;
         }
 
         /// <summary>Redraws the trains and players for the current view.</summary>
@@ -120,8 +176,7 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                 }
             }
 
-            Markers.SetPixels32(markerPixels);
-            Markers.Apply(updateMipmaps: false);
+            Publish(Markers, markerPixels);
         }
 
         public void Dispose()
@@ -132,18 +187,24 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
 
         // ------------------------------------------------------------------
 
+        private static void Publish(Texture2D texture, Color32[] pixels)
+        {
+            texture.SetPixels32(pixels);
+            texture.Apply(updateMipmaps: false);
+        }
+
         /// <summary>
-        /// Map coordinates to texture pixels. Longitude runs across and latitude up, which is the way
-        /// round the mod's own map has them. A texture counts its rows up from the bottom, which for once
-        /// is what is wanted: north ends up at the top with no flip.
+        /// Map coordinates to texture pixels, as floats. Longitude runs across and latitude up, which is
+        /// the way round the mod's own map has them. A texture counts its rows up from the bottom, which
+        /// for once is what is wanted: north ends up at the top with no flip.
         /// </summary>
-        private Vector2Int ToPixel(Vector2 point)
+        private Vector2 ToPixel(Vector2 point)
         {
             float half = Span / 2f;
             float x = (point.y - (Centre.y - half)) / Span;
             float y = (point.x - (Centre.x - half)) / Span;
 
-            return new Vector2Int(Mathf.RoundToInt(x * (Size - 1)), Mathf.RoundToInt(y * (Size - 1)));
+            return new Vector2(x * (Size - 1), y * (Size - 1));
         }
 
         private static Texture2D NewTexture(string name)
@@ -158,47 +219,65 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
             };
         }
 
-        private static void Dot(Color32[] pixels, Vector2Int at, int radius, Color32 colour)
+        private static void Dot(Color32[] pixels, Vector2 at, int radius, Color32 colour)
         {
+            // A marker well off the view would otherwise cost a loop over its whole area for nothing
+            if (at.x < -radius || at.y < -radius || at.x > Size + radius || at.y > Size + radius ||
+                float.IsNaN(at.x) || float.IsNaN(at.y))
+            {
+                return;
+            }
+
+            int cx = Mathf.RoundToInt(at.x);
+            int cy = Mathf.RoundToInt(at.y);
+
             for (int dy = -radius; dy <= radius; dy++)
             {
                 for (int dx = -radius; dx <= radius; dx++)
                 {
                     if (dx * dx + dy * dy <= radius * radius)
                     {
-                        Plot(pixels, at.x + dx, at.y + dy, colour);
+                        Plot(pixels, cx + dx, cy + dy, colour);
                     }
                 }
             }
         }
 
-        /// <summary>Bresenham, so a line off the edge of the view costs a few comparisons and no memory.</summary>
-        private static void Line(Color32[] pixels, Vector2Int from, Vector2Int to, Color32 colour)
+        /// <summary>
+        /// Draws a line, clipped to the view first.
+        /// </summary>
+        /// <remarks>
+        /// Clipping rather than plotting-and-discarding is what keeps this bounded: zoomed well in, a
+        /// segment can run tens of thousands of pixels past the edge of the view, and walking all of it
+        /// to throw every pixel away is how a map turns into a frozen game.
+        /// </remarks>
+        private static void Line(Color32[] pixels, Vector2 from, Vector2 to, Color32 colour)
         {
-            // Both ends far off the same side means the whole segment is: skip it without walking it
-            if ((from.x < 0 && to.x < 0) || (from.y < 0 && to.y < 0) ||
-                (from.x >= Size && to.x >= Size) || (from.y >= Size && to.y >= Size))
+            if (!ClipToView(ref from, ref to))
             {
                 return;
             }
 
-            int dx = Mathf.Abs(to.x - from.x);
-            int dy = -Mathf.Abs(to.y - from.y);
-            int stepX = from.x < to.x ? 1 : -1;
-            int stepY = from.y < to.y ? 1 : -1;
+            int x = Mathf.RoundToInt(from.x);
+            int y = Mathf.RoundToInt(from.y);
+            int toX = Mathf.RoundToInt(to.x);
+            int toY = Mathf.RoundToInt(to.y);
+
+            int dx = Mathf.Abs(toX - x);
+            int dy = -Mathf.Abs(toY - y);
+            int stepX = x < toX ? 1 : -1;
+            int stepY = y < toY ? 1 : -1;
             int error = dx + dy;
 
-            int x = from.x;
-            int y = from.y;
-
-            // A very long segment out of view could otherwise walk a great many steps for nothing
+            // Clipped to the view, so this can never exceed twice its width. Kept as a guard anyway: a
+            // rounding disagreement between the clip and the walk should cost a wonky line, not a hang
             int guard = (dx - dy) + 2;
 
             while (guard-- > 0)
             {
                 Plot(pixels, x, y, colour);
 
-                if (x == to.x && y == to.y)
+                if (x == toX && y == toY)
                 {
                     return;
                 }
@@ -214,6 +293,62 @@ namespace TwitchChat.Plugins.Bundled.Dispatch
                     error += dx;
                     y += stepY;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Liang-Barsky: trims a segment to the visible rectangle, or reports it wholly outside.
+        /// </summary>
+        private static bool ClipToView(ref Vector2 from, ref Vector2 to)
+        {
+            if (float.IsNaN(from.x) || float.IsNaN(from.y) || float.IsNaN(to.x) || float.IsNaN(to.y))
+            {
+                return false;
+            }
+
+            const float min = 0f;
+            float max = Size - 1;
+
+            float dx = to.x - from.x;
+            float dy = to.y - from.y;
+            float enter = 0f;
+            float exit = 1f;
+
+            if (!Trim(-dx, from.x - min, ref enter, ref exit) ||
+                !Trim(dx, max - from.x, ref enter, ref exit) ||
+                !Trim(-dy, from.y - min, ref enter, ref exit) ||
+                !Trim(dy, max - from.y, ref enter, ref exit))
+            {
+                return false;
+            }
+
+            Vector2 start = from;
+            from = new Vector2(start.x + (enter * dx), start.y + (enter * dy));
+            to = new Vector2(start.x + (exit * dx), start.y + (exit * dy));
+            return true;
+
+            static bool Trim(float edge, float distance, ref float enter, ref float exit)
+            {
+                if (Mathf.Approximately(edge, 0f))
+                {
+                    // Parallel to this edge: inside if it starts inside, and no trimming to do
+                    return distance >= 0f;
+                }
+
+                float crossing = distance / edge;
+
+                if (edge < 0f)
+                {
+                    if (crossing > exit) return false;
+                    if (crossing > enter) enter = crossing;
+                }
+                else
+                {
+                    if (crossing < enter) return false;
+                    if (crossing < exit) exit = crossing;
+                }
+
+                return true;
             }
         }
 

--- a/TwitchChat.Plugins.Bundled/Dispatch/MapTextureOwner.cs
+++ b/TwitchChat.Plugins.Bundled/Dispatch/MapTextureOwner.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+
+namespace TwitchChat.Plugins.Bundled.Dispatch
+{
+    /// <summary>
+    /// Ties the map's textures to the lifetime of the object they are shown on.
+    /// </summary>
+    /// <remarks>
+    /// A texture made with <c>new Texture2D</c> belongs to nothing and is not collected when the last
+    /// thing referencing it goes away, so a display closed and reopened a few times would quietly leave
+    /// megabytes behind. Hanging this on the map object means Unity destroys the textures when it
+    /// destroys the panel, which is exactly when they stop being wanted.
+    /// </remarks>
+    internal sealed class MapTextureOwner : MonoBehaviour
+    {
+        private IDisposable? owned;
+
+        internal void Own(IDisposable disposable) => owned = disposable;
+
+        private void OnDestroy()
+        {
+            owned?.Dispose();
+            owned = null;
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Metrics/MetricsContent.cs
+++ b/TwitchChat.Plugins.Bundled/Metrics/MetricsContent.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using TwitchChat.Api;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TwitchChat.Plugins.Bundled.Metrics
+{
+    /// <summary>
+    /// The consist readout: how long the train is, what it weighs, how much of it is braked, and where
+    /// the driver has the controls.
+    /// </summary>
+    internal sealed class MetricsContent : IPanelContent
+    {
+        /// <summary>
+        /// How often the figures are re-read. The mod this reads from walks the whole consist on every
+        /// call and does it twice a frame in its own overlay; four times a second is plenty for numbers
+        /// a human is reading, and costs a fraction of that.
+        /// </summary>
+        private const float RefreshInterval = 0.25f;
+
+        private const int FirstRowY = 35;
+        private const int RowHeight = 18;
+        private const int BarHeight = 18;
+        private const int CaptionX = 10;
+        private const int ValueX = 105;
+
+        private readonly IPanelSurface surface;
+        private readonly MuseumMetrics metrics;
+
+        private readonly List<GameObject> built = new();
+        private readonly List<Row> rows = new();
+        private readonly List<Bar> bars = new();
+
+        private Text? status;
+        private int nextY;
+        private float untilRefresh;
+        private bool layoutDirty;
+
+        internal MetricsContent(IPanelSurface surface, MuseumMetrics metrics)
+        {
+            this.surface = surface;
+            this.metrics = metrics;
+            Rebuild();
+        }
+
+        public void OnShow()
+        {
+            // The mod's per-figure settings can have been changed since this panel was last looked at,
+            // and they decide which rows exist at all
+            Rebuild();
+            Refresh();
+        }
+
+        public void OnHide() { }
+
+        public void OnResize(Vector2 size)
+        {
+            // Resizing fires every frame while an edge is being dragged, and the rows are laid out
+            // against the width, so note it and rebuild on the next refresh instead of on every frame
+            layoutDirty = true;
+        }
+
+        public void Tick(float deltaTime)
+        {
+            untilRefresh -= deltaTime;
+            if (untilRefresh > 0f)
+            {
+                return;
+            }
+
+            untilRefresh = RefreshInterval;
+
+            if (layoutDirty)
+            {
+                layoutDirty = false;
+                Rebuild();
+            }
+
+            Refresh();
+        }
+
+        // ------------------------------------------------------------------
+        // Building
+        // ------------------------------------------------------------------
+
+        private void Rebuild()
+        {
+            foreach (GameObject obj in built)
+            {
+                UnityEngine.Object.Destroy(obj);
+            }
+
+            built.Clear();
+            rows.Clear();
+            bars.Clear();
+            status = null;
+            nextY = FirstRowY;
+
+            AddRow("Cars", "showCars", stats => metrics.Count(stats, "CarCount").ToString());
+            AddRow("Axles", null, stats => metrics.Count(stats, "AxleCount").ToString());
+            AddRow("Length", "showLength", stats => $"{metrics.Number(stats, "TotalLengthMeters"):F0} m");
+            AddRow("Mass", "showMass", stats => $"{metrics.Number(stats, "TotalMassTons"):F1} t");
+            AddRow("  tare / cargo", "showMass", stats =>
+                $"{metrics.Number(stats, "TareMassTons"):F1} / {metrics.Number(stats, "CargoMassTons"):F1} t");
+            AddRow("Braked mass", "showBrakedMass", stats =>
+                $"{metrics.Number(stats, "BrakedMassTons"):F1} t  ({metrics.Number(stats, "BrakedPercentage"):F0}%)");
+            AddRow("Handbrakes", "showHandbrake", stats =>
+                $"{metrics.Count(stats, "HandbrakesSetCount")} / {metrics.Count(stats, "TotalHandbrakesCount")}");
+            AddRow("Brake line", "showBrakeLine", stats =>
+                metrics.Flag(stats, "IsBrakeLineComplete") ? "continuous" : "BROKEN");
+            AddRow("Rear pipe", "showRearPressure", stats => $"{metrics.Number(stats, "RearBrakePipePressure"):F2} bar");
+            AddRow("Locos running", "showActiveLocos", stats => metrics.Count(stats, "ActiveLocoCount").ToString());
+
+            // Hazmat has no setting of its own in that mod, and a consist with none is the normal case,
+            // so this row says nothing rather than saying zero
+            AddRow("Hazmat cars", null, stats =>
+            {
+                int hazmat = metrics.Count(stats, "HazmatCarCount");
+                return hazmat > 0 ? hazmat.ToString() : "none";
+            });
+
+            AddSeparator();
+
+            AddBar("Throttle", "showThrottle", "ThrottleValue");
+            AddBar("Train brake", "showTrainBrake", "TrainBrakeValue");
+            AddBar("Loco brake", "showLocoBrake", "LocoBrakeValue");
+
+            // Only worth a row on a locomotive that has one
+            AddBar("Dynamic", "showTrainBrake", "DynamicBrakeValue", stats => metrics.Flag(stats, "HasDynamicBrake"));
+
+            nextY += 6;
+            status = surface.Widgets.CreateText(surface.Root, string.Empty, CaptionX, nextY, Color.gray, lines: 3);
+            built.Add(status.gameObject);
+        }
+
+        private void AddRow(string caption, string? setting, Func<object, string> value)
+        {
+            if (setting != null && !metrics.Shows(setting))
+            {
+                return;
+            }
+
+            Text captionLabel = surface.Widgets.CreateLabel(surface.Root, caption, CaptionX, nextY, Color.gray);
+            Text valueLabel = surface.Widgets.CreateText(surface.Root, "--", ValueX, nextY, Color.white);
+
+            built.Add(captionLabel.gameObject);
+            built.Add(valueLabel.gameObject);
+            rows.Add(new Row(valueLabel, value));
+
+            nextY += RowHeight;
+        }
+
+        private void AddSeparator()
+        {
+            nextY += 4;
+            built.Add(surface.Widgets.CreateSeparator(surface.Root, nextY));
+            nextY += 6;
+        }
+
+        private void AddBar(string caption, string? setting, string field, Func<object, bool>? applies = null)
+        {
+            if (setting != null && !metrics.Shows(setting))
+            {
+                return;
+            }
+
+            GameObject bar = surface.Widgets.CreateValueBar(surface.Root, caption, nextY, BarColour(field));
+            built.Add(bar);
+            bars.Add(new Bar(bar, field, applies));
+
+            nextY += BarHeight;
+        }
+
+        /// <summary>Brakes read red, power reads blue, so a glance says which way the train is being asked to go.</summary>
+        private static Color BarColour(string field)
+        {
+            return field == "ThrottleValue"
+                ? new Color(0.2f, 0.7f, 0.3f, 0.9f)
+                : new Color(0.85f, 0.35f, 0.25f, 0.9f);
+        }
+
+        // ------------------------------------------------------------------
+        // Refreshing
+        // ------------------------------------------------------------------
+
+        private void Refresh()
+        {
+            object? stats = ReadStats(out string problem);
+
+            foreach (Row row in rows)
+            {
+                row.Value.text = stats == null ? "--" : row.Format(stats);
+            }
+
+            foreach (Bar bar in bars)
+            {
+                bool applies = stats != null && (bar.Applies == null || bar.Applies(stats));
+                bar.Object.SetActive(applies);
+
+                if (applies && stats != null)
+                {
+                    surface.Widgets.SetValueBar(bar.Object, metrics.Number(stats, bar.Field));
+                }
+            }
+
+            if (status != null)
+            {
+                string warnings = stats == null ? string.Empty : metrics.Warnings(stats);
+                status.text = problem.Length > 0 ? problem : warnings;
+                status.color = problem.Length > 0 ? Color.gray : new Color(1f, 0.75f, 0.2f);
+            }
+        }
+
+        /// <summary>
+        /// The figures for the train the player is on, and if there are none, why not in words the player
+        /// can act on.
+        /// </summary>
+        private object? ReadStats(out string problem)
+        {
+            problem = string.Empty;
+
+            if (!metrics.IsInstalled)
+            {
+                problem = "The Loco Metrics mod is not installed.";
+                return null;
+            }
+
+            TrainCar? car = PlayerManager.Car;
+            if (car == null)
+            {
+                problem = "Board a train to see its figures.";
+                return null;
+            }
+
+            object? stats = metrics.StatsFor(car.trainset);
+            if (stats == null)
+            {
+                problem = metrics.Error ?? "The Loco Metrics mod did not answer.";
+            }
+
+            return stats;
+        }
+
+        private sealed class Row
+        {
+            internal Row(Text value, Func<object, string> format)
+            {
+                Value = value;
+                Format = format;
+            }
+
+            internal Text Value { get; }
+            internal Func<object, string> Format { get; }
+        }
+
+        private sealed class Bar
+        {
+            internal Bar(GameObject obj, string field, Func<object, bool>? applies)
+            {
+                Object = obj;
+                Field = field;
+                Applies = applies;
+            }
+
+            internal GameObject Object { get; }
+            internal string Field { get; }
+            internal Func<object, bool>? Applies { get; }
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Metrics/MetricsPlugin.cs
+++ b/TwitchChat.Plugins.Bundled/Metrics/MetricsPlugin.cs
@@ -1,0 +1,22 @@
+using TwitchChat.Api;
+
+namespace TwitchChat.Plugins.Bundled.Metrics
+{
+    /// <summary>
+    /// Puts the consist metrics from "Unrestored Museum Loco Tracker And Loco Metrics" on a display,
+    /// where a VR driver can actually read them. That mod draws them in a screen corner with legacy
+    /// IMGUI, which a headset never sees.
+    /// </summary>
+    public sealed class MetricsPlugin : ITwitchChatPlugin
+    {
+        private readonly MuseumMetrics metrics = new();
+
+        public string Id => "Metrics";
+
+        public string Title => "Metrics";
+
+        public bool IsAvailable => metrics.IsInstalled;
+
+        public IPanelContent CreateContent(IPanelSurface surface) => new MetricsContent(surface, metrics);
+    }
+}

--- a/TwitchChat.Plugins.Bundled/Metrics/MuseumMetrics.cs
+++ b/TwitchChat.Plugins.Bundled/Metrics/MuseumMetrics.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using TwitchChat.Api;
+
+namespace TwitchChat.Plugins.Bundled.Metrics
+{
+    /// <summary>
+    /// Reads the consist figures out of DSH's "Unrestored Museum Loco Tracker And Loco Metrics".
+    /// </summary>
+    /// <remarks>
+    /// That mod does the arithmetic in <c>TrainCalculator.CalculateSetStats</c>, a public static that
+    /// takes a trainset and returns a struct of figures, with no side effects and nothing cached. That
+    /// makes it callable from here, which is much better than working the numbers out again: the panel
+    /// and the mod's own overlay then agree by construction rather than by our getting the same brake
+    /// arithmetic right independently.
+    /// <para>
+    /// Reflection rather than a reference, and no code copied: the mod's licence is contradictory, its
+    /// LICENSE file being GPL-3.0 while its README claims MIT.
+    /// </para>
+    /// </remarks>
+    internal sealed class MuseumMetrics
+    {
+        internal const string ModId = "UnrestoredMuseumLocoTracker";
+
+        private readonly ModBinder binder = new(ModId);
+
+        private MethodInfo? calculate;
+        private bool lookedUp;
+
+        /// <summary>Whether the mod is installed and switched on.</summary>
+        internal bool IsInstalled => binder.IsModPresent;
+
+        /// <summary>What went wrong, in a few words, or null while nothing has.</summary>
+        internal string? Error => binder.Error;
+
+        /// <summary>
+        /// The figures for a trainset, as a boxed struct to be read with <see cref="Number"/> and friends,
+        /// or null if the mod is not there or would not answer.
+        /// </summary>
+        internal object? StatsFor(object? trainset)
+        {
+            if (trainset == null)
+            {
+                return null;
+            }
+
+            if (!lookedUp)
+            {
+                lookedUp = true;
+                calculate = binder.Method(binder.Type("DerailValleyMuseumMap.TrainCalculator"), "CalculateSetStats");
+
+                if (calculate == null && binder.Assembly != null)
+                {
+                    binder.Fail("TrainCalculator.CalculateSetStats was not found; this version of the mod is not one this panel knows.");
+                }
+            }
+
+            return binder.Invoke(calculate, null, trainset);
+        }
+
+        internal float Number(object? stats, string field) => binder.ReadFloat(stats, field);
+
+        internal int Count(object? stats, string field) => binder.ReadInt(stats, field);
+
+        internal bool Flag(object? stats, string field) => binder.ReadBool(stats, field);
+
+        /// <summary>
+        /// The mod's own per-figure visibility settings, so the panel shows what the player asked that
+        /// mod to show. Anything unrecognised is treated as shown, which is the friendlier way to be
+        /// wrong: a new figure appears rather than silently going missing.
+        /// </summary>
+        internal bool Shows(string setting)
+        {
+            object? settings = binder.ReadStatic(binder.Type("DerailValleyMuseumMap.Main"), "Settings");
+            return settings == null || binder.ReadBool(settings, setting, fallback: true);
+        }
+
+        /// <summary>
+        /// The low-resource warnings, flattened to one line. The mod may hold these as a string or as a
+        /// collection of them, and which it is has no business mattering here.
+        /// </summary>
+        internal string Warnings(object? stats)
+        {
+            object? value = binder.Read(stats, "LowResourceWarnings");
+
+            return value switch
+            {
+                null => string.Empty,
+                string text => text,
+                IEnumerable items => string.Join(", ", items
+                    .Cast<object?>()
+                    .Select(item => item?.ToString() ?? string.Empty)
+                    .Where(text => text.Length > 0)
+                    .ToArray()),
+                _ => value.ToString() ?? string.Empty
+            };
+        }
+    }
+}

--- a/TwitchChat.Plugins.Bundled/TwitchChat.Plugins.Bundled.csproj
+++ b/TwitchChat.Plugins.Bundled/TwitchChat.Plugins.Bundled.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<AssemblyName>TwitchChat.Api</AssemblyName>
-		<RootNamespace>TwitchChat.Api</RootNamespace>
+		<AssemblyName>TwitchChat.Plugins.Bundled</AssemblyName>
+		<RootNamespace>TwitchChat.Plugins.Bundled</RootNamespace>
 		<TargetFramework>net48</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
@@ -9,14 +9,25 @@
 		<OutputType>Library</OutputType>
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 		<DebugType>none</DebugType>
-		<!--
-			The version third-party plugins compile against. Bump the minor for additive changes and the
-			major for anything that breaks an existing plugin; TwitchChatPlugins.ApiVersion must match.
-		-->
-		<Version>1.1.0</Version>
 	</PropertyGroup>
 
+	<!--
+		The panels shipped with the mod, loaded through exactly the same folder as any third-party plugin.
+		Nothing here references TwitchChat.dll: if the API is not enough to write these three panels with,
+		it is not enough for anyone else either.
+
+		Nor does anything here reference the mods being reported on. Those are read by reflection through
+		ModBinder, so a panel for a mod that is not installed costs nothing and breaks nothing.
+	-->
 	<ItemGroup>
+		<ProjectReference Include="..\TwitchChat.Api\TwitchChat.Api.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Reference Include="Assembly-CSharp">
+			<HintPath>$(DerailValleyManagedAssets)Assembly-CSharp.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="UnityEngine">
 			<HintPath>$(DerailValleyManagedAssets)UnityEngine.dll</HintPath>
 			<Private>false</Private>
@@ -37,14 +48,18 @@
 			<HintPath>$(DerailValleyManagedAssets)UnityEngine.TextRenderingModule.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="Newtonsoft.Json">
+			<HintPath>$(DerailValleyManagedAssets)Newtonsoft.Json.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="UnityModManager">
 			<HintPath>$(DerailValleyManagedAssets)UnityModManager\UnityModManager.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 	</ItemGroup>
 
-	<Target Name="CopyApiToMods" AfterTargets="PostBuildEvent">
-		<MakeDir Directories="$(ModOutputPath)" />
-		<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(ModOutputPath)" />
+	<Target Name="CopyPluginToMods" AfterTargets="PostBuildEvent">
+		<MakeDir Directories="$(ModOutputPath)\Plugins" />
+		<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(ModOutputPath)\Plugins" />
 	</Target>
 </Project>

--- a/TwitchChat.csproj
+++ b/TwitchChat.csproj
@@ -135,14 +135,21 @@
 		match. Keep it referenced and not compiled.
 	-->
 	<ItemGroup>
-		<Compile Remove="TwitchChat.Api\**" />
-		<None Remove="TwitchChat.Api\**" />
-		<EmbeddedResource Remove="TwitchChat.Api\**" />
+		<Compile Remove="TwitchChat.Api\**;TwitchChat.Plugins.Bundled\**" />
+		<None Remove="TwitchChat.Api\**;TwitchChat.Plugins.Bundled\**" />
+		<EmbeddedResource Remove="TwitchChat.Api\**;TwitchChat.Plugins.Bundled\**" />
 	</ItemGroup>
 
 	<!-- The public contract plugins compile against; shipped beside this assembly -->
 	<ItemGroup>
 		<ProjectReference Include="TwitchChat.Api\TwitchChat.Api.csproj" />
+
+		<!--
+			Not a reference, only an ordering: the mod knows nothing about the bundled plugins and finds
+			them the same way it would find anyone else's. This is here so that the Release packaging step,
+			which runs after this project builds, has their assemblies to pick up.
+		-->
+		<ProjectReference Include="TwitchChat.Plugins.Bundled\TwitchChat.Plugins.Bundled.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<!-- Development/Build Time Only Packages -->

--- a/TwitchChat.csproj
+++ b/TwitchChat.csproj
@@ -6,10 +6,10 @@
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
 		<OutputType>Library</OutputType>
-		<DerailValleyManagedAssets>D:\SteamLibrary\steamapps\common\Derail Valley\DerailValley_Data\Managed\</DerailValleyManagedAssets> <!-- Change to local game install path during build -->
+		<!-- DerailValleyManagedAssets and ModOutputPath come from Directory.Build.props, shared with the API project -->
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 		<DebugType>none</DebugType>
-		<ModVersion>3.4.2</ModVersion>
+		<ModVersion>3.5.0</ModVersion>
 		<ModAuthor>Nightwind416</ModAuthor>
 		<GameVersion>build 99</GameVersion>
 		<EntryMethod>TwitchChat.Main.Load</EntryMethod>
@@ -128,6 +128,23 @@
 		</PackageReference>
 	</ItemGroup>
 
+	<!--
+		The API project lives in a subfolder, so the SDK's source glob would otherwise compile its files
+		into this assembly as well as referencing them. That would give the mod its own private copies of
+		the interfaces, which would not be the same types a plugin implements, and no plugin would ever
+		match. Keep it referenced and not compiled.
+	-->
+	<ItemGroup>
+		<Compile Remove="TwitchChat.Api\**" />
+		<None Remove="TwitchChat.Api\**" />
+		<EmbeddedResource Remove="TwitchChat.Api\**" />
+	</ItemGroup>
+
+	<!-- The public contract plugins compile against; shipped beside this assembly -->
+	<ItemGroup>
+		<ProjectReference Include="TwitchChat.Api\TwitchChat.Api.csproj" />
+	</ItemGroup>
+
 	<!-- Development/Build Time Only Packages -->
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" PrivateAssets="all" />
@@ -146,6 +163,7 @@
 	"GameVersion": "$(GameVersion)",
 	"EntryMethod": "$(EntryMethod)",
 	"ManagerVersion": "$(ManagerVersion)",
+	"LoadAfter": [ "RemoteDispatch", "AITraffic", "UnrestoredMuseumLocoTracker" ],
 	"Homepage": "$(ModHomepage)",
 	"Repository": "$(ModRepository)"
 }
@@ -163,11 +181,8 @@
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		 <!-- Copy to game mods folder -->
-        <PropertyGroup>
-            <ModOutputPath>D:\SteamLibrary\steamapps\common\Derail Valley\Mods\TwitchChat</ModOutputPath>
-        </PropertyGroup>
         <MakeDir Directories="$(ModOutputPath)" />
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll;$(OutputPath)info.json" DestinationFolder="$(ModOutputPath)" />
+        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll;$(OutputPath)info.json;$(OutputPath)TwitchChat.Api.dll" DestinationFolder="$(ModOutputPath)" />
         
         <!-- Package after Release build -->
         <Exec Condition="'$(ConfigurationName)' == 'Release' And '$(OS)' == 'Windows_NT'" Command="powershell -executionpolicy bypass -Command &quot;./package.ps1&quot;" />

--- a/TwitchChat.sln
+++ b/TwitchChat.sln
@@ -6,6 +6,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchChat", "TwitchChat.cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchChat.Api", "TwitchChat.Api\TwitchChat.Api.csproj", "{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchChat.Plugins.Bundled", "TwitchChat.Plugins.Bundled\TwitchChat.Plugins.Bundled.csproj", "{2E9D77B4-51C8-4A3F-B0D6-8F1E4C7A9D23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,5 +25,9 @@ Global
 		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E9D77B4-51C8-4A3F-B0D6-8F1E4C7A9D23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E9D77B4-51C8-4A3F-B0D6-8F1E4C7A9D23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E9D77B4-51C8-4A3F-B0D6-8F1E4C7A9D23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E9D77B4-51C8-4A3F-B0D6-8F1E4C7A9D23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/TwitchChat.sln
+++ b/TwitchChat.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchChat", "TwitchChat.csproj", "{35FB73C9-194D-4B06-8327-9200CAF9BF7D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchChat.Api", "TwitchChat.Api\TwitchChat.Api.csproj", "{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,5 +19,9 @@ Global
 		{35FB73C9-194D-4B06-8327-9200CAF9BF7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35FB73C9-194D-4B06-8327-9200CAF9BF7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35FB73C9-194D-4B06-8327-9200CAF9BF7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C1B0A64-3F5E-4C2D-9E88-2B4A6D1F0C11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,146 @@
+# Writing a panel for TwitchChat
+
+TwitchChat puts world-space panels in the locomotive cab and on the back of a VR hand. They are the
+only comfortable way to read anything at all in Derail Valley VR, and there is no reason they should
+only ever show Twitch chat. This is how to put your own content on them.
+
+A plugin is a small assembly that implements one interface. It does not reference `TwitchChat.dll`,
+only `TwitchChat.Api.dll`, which ships beside it in the mod's folder.
+
+## The shortest possible plugin
+
+```csharp
+using TwitchChat.Api;
+using UnityEngine;
+
+public class SpeedPlugin : ITwitchChatPlugin
+{
+    public string Id => "MyMod.Speed";   // stable: it is saved as "the panel this display shows"
+    public string Title => "Speed";      // the title row, and the button in the Mods menu
+    public bool IsAvailable => true;     // false to leave the panel out entirely
+
+    public IPanelContent CreateContent(IPanelSurface surface) => new SpeedContent(surface);
+}
+
+public class SpeedContent : IPanelContent
+{
+    private readonly Text readout;
+    private float next;
+
+    public SpeedContent(IPanelSurface surface)
+    {
+        surface.Widgets.CreateSection(surface.Root, "Speed", 35, 40);
+        readout = surface.Widgets.CreateLabel(surface.Root, "-- km/h", 15, 55);
+    }
+
+    public void OnShow() { }
+    public void OnHide() { }
+    public void OnResize(Vector2 size) { }
+
+    public void Tick(float deltaTime)
+    {
+        // Four times a second is plenty. Tick runs every frame, and a panel is not worth a frame.
+        next -= deltaTime;
+        if (next > 0f) return;
+        next = 0.25f;
+
+        TrainCar? car = PlayerManager.Car;
+        readout.text = car == null ? "not aboard" : $"{car.GetForwardSpeed() * 3.6f:F0} km/h";
+    }
+}
+```
+
+Build it against `TwitchChat.Api.dll` and drop the result in
+`Derail Valley/Mods/TwitchChat/Plugins/`. It appears on the **Mods** panel, reachable from the Main
+panel of every display.
+
+## Getting registered
+
+There are two routes and they end in the same place.
+
+**Drop it in the Plugins folder.** TwitchChat scans `Mods/TwitchChat/Plugins/*.dll` during load and
+instantiates every public, non-abstract `ITwitchChatPlugin` with a parameterless constructor. Nothing
+else is needed, and the mod you are reporting on need not know you exist. This is how the panels
+shipped with TwitchChat get in.
+
+**Or register from your own mod.** If you already have a mod, reference `TwitchChat.Api.dll` and call
+this from your `Load`:
+
+```csharp
+TwitchChatPlugins.Register(new SpeedPlugin());
+```
+
+Load order does not matter. TwitchChat picks up whatever registered before it started and is told
+about anything that registers afterwards. If TwitchChat is not installed at all, the call is simply
+never reached, because the assembly it lives in is never loaded — guard it with a check for the mod
+if you would rather be explicit.
+
+## Where to put things
+
+`IPanelSurface` gives you two parents, matching how the mod's own panels are built:
+
+- **`Root`** — the panel itself. Widgets here are positioned by hand, in canvas units measured down
+  from the top, and stay put. The title row takes roughly the first 30 units. Use this for a header,
+  a fixed set of rows, or a row of buttons.
+- **`Content`** — the scrolling area. Children are laid out top to bottom and the area scrolls once
+  they no longer fit. Use this for a list whose length you do not control.
+
+Build with `surface.Widgets` rather than raw uGUI. You get the same fonts and spacing as the rest of
+the mod, VR poke colliders on anything clickable, and your panel is recoloured along with everything
+else when the player changes the colour settings.
+
+## Rules worth knowing
+
+**Everything is on Unity's main thread.** `CreateContent`, `Tick`, `OnShow`, `OnHide` and `OnResize`
+are all called from the game loop. If you fetch something on a background thread, marshal the result
+back yourself before touching a widget.
+
+**Any collider you add must be a trigger.** A solid collider on a panel parented to a locomotive gets
+folded into that locomotive's rigidbody, shifts its mass and shoves it around the track. The widget
+factory already does the right thing; this matters only if you add colliders of your own.
+
+**Panels have no size of their own.** A display is whatever size the player has dragged it to, and
+your panel gets that size whichever it is. Anchor things rather than assuming a width, and use
+`OnResize` if you draw something that has to be regenerated.
+
+**You get one content object per display.** A player can have up to five displays in a locomotive
+plus the wrist panel, so `CreateContent` may be called six times and all six results are alive at
+once. Keep per-panel state in the content object, not in the plugin.
+
+**Read other mods by reflection, not by reference.** `ModBinder` in the API assembly does the caching
+and the swallowing of failures. Referencing another mod's assembly directly means your plugin fails
+to load whenever that mod is absent, and ties you to its version:
+
+```csharp
+private readonly ModBinder ai = new("AITraffic");
+
+public bool IsAvailable => ai.IsModPresent;
+
+// ...
+Type? manager = ai.Type("AITraffic.Core.TrafficManager");
+object? instance = ai.Invoke(ai.Property(manager, "Instance")?.GetGetMethod(), null);
+int trains = ai.ReadOr(instance, "ActiveTrainCount", 0);
+```
+
+`ModBinder` returns null rather than throwing, and stops for good after the first hard failure so a
+mod that has changed shape is reported once instead of every frame.
+
+**Failing is survivable.** If your content throws, TwitchChat stops driving it, writes the exception
+to the mod's log, and puts a message on the panel. It does not take the display, the other panels, or
+the frame down with it. This is a safety net, not a licence — catch what you can predict.
+
+## Versioning
+
+`TwitchChatPlugins.ApiVersion` and the assembly version of `TwitchChat.Api.dll` move together. A
+plugin built against a different **major** version is refused at load with a line in the log saying
+so. Additive changes bump the minor and existing plugins keep working.
+
+## Settings and identity
+
+`Id` is written into the player's settings as the panel a display was last showing, and it is the key
+the on/off switch on the Mods panel uses. Changing it after release makes every display that was
+showing your panel fall back to the Main menu, and forgets whether the player had switched it off.
+Prefix it with something of your own — `MyMod.Speed` rather than `Speed` — so two plugins cannot
+collide. The first plugin to claim an id keeps it; a second is refused with a line in the log.
+
+Your own configuration is your own business: keep it in your mod's settings, not TwitchChat's.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -95,6 +95,34 @@ else when the player changes the colour settings.
 are all called from the game loop. If you fetch something on a background thread, marshal the result
 back yourself before touching a widget.
 
+**But do not assume the mod you are reading wants to be called from there.** A method that looks
+synchronous may hand its work to that mod's own main-thread pump and wait for the answer, because
+the callers it was written for are worker threads — an HTTP handler, say. Call such a method from
+`Tick` and the main thread waits for something only the main thread can do, which is a deadlock that
+throws nothing, logs nothing, and freezes the whole game. This is not hypothetical: it is exactly
+what the bundled Dispatch Map panel did before it was moved off the game loop.
+
+If a mod's API is built for worker threads, read it on one and collect the answer a frame or two
+later:
+
+```csharp
+private Task<Thing>? request;
+
+public void Tick(float deltaTime)
+{
+    request ??= Task.Run(() => ReadTheOtherMod());   // never on this thread
+    if (!request.IsCompleted) return;                // still out; last frame's picture still stands
+
+    Thing thing = request.Result;
+    request = null;
+    ShowIt(thing);                                   // back on the main thread, safe for widgets
+}
+```
+
+Keep only one request in flight, do no Unity work inside it, and let the result be plain data.
+A read that throws out there is only a failed read; the same read on the game loop can be the end of
+the session.
+
 **Any collider you add must be a trigger.** A solid collider on a panel parented to a locomotive gets
 folded into that locomotive's rigidbody, shifts its mass and shoves it around the track. The widget
 factory already does the right thing; this matters only if you add colliders of your own.

--- a/package.ps1
+++ b/package.ps1
@@ -17,8 +17,9 @@ $FilesToInclude = @(
 )
 
 # Plugin assemblies, each contributing panels through TwitchChat.Api. Shipped in their own folder so a
-# player can remove one without touching the mod itself.
+# player can remove one without touching the mod itself. Each is listed as project directory / file name.
 $PluginsToInclude = @(
+    @{ Project = "TwitchChat.Plugins.Bundled"; File = "TwitchChat.Plugins.Bundled.dll" }
 )
 
 # Get mod info from build output
@@ -53,7 +54,8 @@ if ($PluginsToInclude.Count -gt 0) {
     New-Item "$PluginDir" -ItemType Directory -Force | Out-Null
 
     foreach ($plugin in $PluginsToInclude) {
-        $sourcePath = "$BuildDir/$plugin"
+        # Each plugin is its own project, so it builds into its own bin rather than the mod's
+        $sourcePath = "$PSScriptRoot/$($plugin.Project)/bin/$Configuration/net48/$($plugin.File)"
         if (Test-Path $sourcePath) {
             Copy-Item -Force -Path $sourcePath -Destination "$PluginDir"
         } else {

--- a/package.ps1
+++ b/package.ps1
@@ -12,7 +12,13 @@ $BuildDir = "$PSScriptRoot/bin/$Configuration/net48"
 # Files to include from build directory
 $FilesToInclude = @(
     "info.json",
-    "TwitchChat.dll"
+    "TwitchChat.dll",
+    "TwitchChat.Api.dll"    # The contract plugins compile against; must sit beside TwitchChat.dll
+)
+
+# Plugin assemblies, each contributing panels through TwitchChat.Api. Shipped in their own folder so a
+# player can remove one without touching the mod itself.
+$PluginsToInclude = @(
 )
 
 # Get mod info from build output
@@ -38,6 +44,21 @@ foreach ($file in $FilesToInclude) {
         Copy-Item -Force -Path $sourcePath -Destination "$ModDir"    # Changed destination
     } else {
         Write-Warning "Build file not found: $sourcePath"
+    }
+}
+
+# Copy plugin assemblies into their own folder, which is where the mod looks for them
+if ($PluginsToInclude.Count -gt 0) {
+    $PluginDir = "$ModDir/Plugins"
+    New-Item "$PluginDir" -ItemType Directory -Force | Out-Null
+
+    foreach ($plugin in $PluginsToInclude) {
+        $sourcePath = "$BuildDir/$plugin"
+        if (Test-Path $sourcePath) {
+            Copy-Item -Force -Path $sourcePath -Destination "$PluginDir"
+        } else {
+            Write-Warning "Plugin not found: $sourcePath"
+        }
     }
 }
 


### PR DESCRIPTION
The world-space displays are the only comfortable way to read anything in DV VR, and until now they could only ever show Twitch chat. Several other mods work out things worth knowing while driving and then draw them to the flat screen, where a headset never sees them. This opens the displays to those readouts, and ships three.

## Why it had to be re-rendered rather than mirrored

All three target mods draw with legacy IMGUI, or not in the game at all. IMGUI goes straight to the screen overlay and cannot be retargeted onto a world-space canvas; Remote Dispatch renders nothing in Unity, serving a Leaflet page to a browser instead. So there is no hosting another mod's overlay — every panel is drawn again from that mod's own live data.

## The plugin API

The thirteen panels were spelled out in five parallel places: a typed property per panel on the host, the construction, the back-button wiring, the hiding, the showing, and the per-frame refresh. They now come from one registry, which the mod's own panels join on exactly the same terms as a plugin.

The contract is a small assembly of its own, `TwitchChat.Api`, shipped beside the mod. A plugin either drops a DLL in the mod's `Plugins` folder or, if it is a mod already, references the API and registers itself; load order does not matter either way. Panels are built with the mod's own widget factories, so they are themed by the colour settings like everything else, and a plugin that throws loses its own panel and says so on it rather than taking the display down.

The three bundled panels are their own assembly, loaded through that same folder and referencing only `TwitchChat.Api`. If the public API were not enough to write them with, it would not be enough for anyone else either, and building them any other way would have hidden that.

`docs/PLUGINS.md` documents the contract with a worked example.

## The three panels

Each appears only if the mod it reports on is installed, and each is read by reflection — no code copied, no assembly referenced. That is the right shape regardless, and doubly so here: AI Traffic has no licence file at all, and Museum & Metrics contradicts itself (GPL-3.0 LICENSE, MIT README).

- **Metrics** — consist figures from DSH's Loco Metrics. Calls that mod's own `TrainCalculator.CalculateSetStats`, so the panel and its overlay agree by construction rather than by our redoing the brake arithmetic, and honours its per-figure visibility settings.
- **AI Traffic** — what every AI train is doing, plus switches for that mod's own loco nametags, route lines and signal tags. Those three are drawn in the world, so they are worth having in VR, and the only other way to reach them was the UMM menu.
- **Dispatch Map** — the track, junctions and which way each is thrown, every car, locomotive and player, with zoom, panning and Follow. Read in process, so no port, no password and no need for the web server. An overview only: no job list, no car list, no locomotive control.

The main menu's fixed button layout was already full, so plugin panels are listed on a new **Mods** panel with a per-plugin on/off switch, mirrored on the UMM page with a line saying whether each mod was actually found.

## For reviewers

**The Dispatch Map froze the game twice during testing, and the cause is worth knowing.** Remote Dispatch's data statics look synchronous but hand their work to that mod's own main-thread pump and wait, because the callers they were written for are HTTP worker threads. Called from the game loop, the main thread waits for something only the main thread can do: a deadlock that throws nothing, logs nothing, and takes the session with it. Nothing in the signature `JObject GetAllCarDataJson()` hints at it. All reads now happen on a worker and are collected a frame or two later. This is called out in `docs/PLUGINS.md` so the next plugin author does not repeat it.

Also worth a look:

- Plugin diagnostics were being filtered out at the default debug level, so the first freeze left a panel saying it had stopped and a log with nothing in it. Plugin sources are now always recorded.
- `Main.LogEntry` retried failed writes three times with a one-second sleep, on the game loop — a log file held open by a text editor could stall the game for three seconds per line. It now drops the line to the manager's log instead.
- The API project sits in a subfolder, so the SDK's source glob was compiling its files into the mod as well as referencing them. That would have given the mod private copies of the interfaces, which no plugin could ever have matched.

**Testing status:** the framework, the Metrics panel and the AI Traffic panel have been exercised in game. The Dispatch Map has not been seen working yet — the two freezes were diagnosed and fixed, but the fixed version has not had a successful run. Every binding in all three panels was verified against the mods' assembly metadata rather than assumed.

The branch also carries one unrelated pre-existing commit moving coloured announcements from the roadmap to the feature list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)